### PR TITLE
feat: Add encrypted credentials database with multi-backend support

### DIFF
--- a/server/core/config.py
+++ b/server/core/config.py
@@ -88,6 +88,15 @@ class Settings(BaseSettings):
     api_key_encryption_key: str = Field(env="API_KEY_ENCRYPTION_KEY", min_length=32)
     api_key_cache_ttl: int = Field(default=2592000, env="API_KEY_CACHE_TTL", ge=3600)
 
+    # Credentials Database (separate encrypted database for API keys and OAuth tokens)
+    credentials_db_path: str = Field(default="credentials.db", env="CREDENTIALS_DB_PATH")
+
+    # Credential Backend Selection
+    # Options: fernet (default), keyring (OS-native), aws (AWS Secrets Manager)
+    credential_backend: Literal["fernet", "keyring", "aws"] = Field(default="fernet", env="CREDENTIAL_BACKEND")
+    aws_secret_arn: Optional[str] = Field(default=None, env="AWS_SECRET_ARN")
+    aws_region: Optional[str] = Field(default=None, env="AWS_REGION")
+
     # Logging
     log_level: str = Field(default="INFO", env="LOG_LEVEL")
     log_format: str = Field(default="json", env="LOG_FORMAT")

--- a/server/core/credential_backends.py
+++ b/server/core/credential_backends.py
@@ -1,0 +1,376 @@
+"""
+Multi-backend credential storage abstraction.
+
+Supports three backends for different deployment scenarios:
+- Fernet: Default, uses encrypted SQLite database (Docker, local dev)
+- Keyring: OS-native credential storage (Windows Credential Locker, macOS Keychain, Linux Secret Service)
+- AWS: AWS Secrets Manager for cloud production deployments
+
+Usage:
+    backend = create_backend(settings, credentials_db)
+    await backend.store("api_key", "sk-xxx", {"provider": "openai"})
+    value = await backend.retrieve("api_key")
+"""
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class CredentialBackend(ABC):
+    """Abstract base class for credential storage backends."""
+
+    @abstractmethod
+    async def store(self, key: str, value: str, metadata: Optional[Dict[str, Any]] = None) -> bool:
+        """Store a credential with optional metadata."""
+        pass
+
+    @abstractmethod
+    async def retrieve(self, key: str) -> Optional[str]:
+        """Retrieve a credential by key."""
+        pass
+
+    @abstractmethod
+    async def delete(self, key: str) -> bool:
+        """Delete a credential by key."""
+        pass
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Check if this backend is available/configured."""
+        pass
+
+
+class FernetBackend(CredentialBackend):
+    """
+    Fernet-encrypted SQLite backend (default).
+
+    Uses the existing CredentialsDatabase for encrypted storage.
+    Best for: Docker deployments, local development.
+    """
+
+    def __init__(self, credentials_db):
+        self._credentials_db = credentials_db
+
+    async def store(self, key: str, value: str, metadata: Optional[Dict[str, Any]] = None) -> bool:
+        """Store credential in encrypted SQLite database."""
+        try:
+            # Parse key format: {type}_{provider}_{session_id} or {type}_{provider}_{customer_id}
+            parts = key.split("_", 2)
+            if len(parts) >= 2:
+                key_type = parts[0]  # api_key or oauth
+                provider = parts[1]
+
+                if key_type == "apikey":
+                    session_id = parts[2] if len(parts) > 2 else "default"
+                    models = metadata.get("models", []) if metadata else []
+                    await self._credentials_db.save_api_key(provider, value, models, session_id)
+                elif key_type == "oauth":
+                    customer_id = parts[2] if len(parts) > 2 else "owner"
+                    await self._credentials_db.save_oauth_tokens(
+                        provider=provider,
+                        access_token=value,
+                        refresh_token=metadata.get("refresh_token", "") if metadata else "",
+                        email=metadata.get("email") if metadata else None,
+                        name=metadata.get("name") if metadata else None,
+                        scopes=metadata.get("scopes") if metadata else None,
+                        customer_id=customer_id,
+                    )
+                else:
+                    # Generic key storage
+                    await self._credentials_db.save_api_key(key, value, [], "default")
+                return True
+            else:
+                # Simple key-value storage
+                await self._credentials_db.save_api_key(key, value, [], "default")
+                return True
+        except Exception as e:
+            logger.error(f"FernetBackend store failed: {e}")
+            return False
+
+    async def retrieve(self, key: str) -> Optional[str]:
+        """Retrieve credential from encrypted SQLite database."""
+        try:
+            parts = key.split("_", 2)
+            if len(parts) >= 2:
+                key_type = parts[0]
+                provider = parts[1]
+
+                if key_type == "apikey":
+                    session_id = parts[2] if len(parts) > 2 else "default"
+                    return await self._credentials_db.get_api_key(provider, session_id)
+                elif key_type == "oauth":
+                    customer_id = parts[2] if len(parts) > 2 else "owner"
+                    tokens = await self._credentials_db.get_oauth_tokens(provider, customer_id)
+                    return tokens.get("access_token") if tokens else None
+            else:
+                return await self._credentials_db.get_api_key(key, "default")
+        except Exception as e:
+            logger.error(f"FernetBackend retrieve failed: {e}")
+            return None
+
+    async def delete(self, key: str) -> bool:
+        """Delete credential from encrypted SQLite database."""
+        try:
+            parts = key.split("_", 2)
+            if len(parts) >= 2:
+                key_type = parts[0]
+                provider = parts[1]
+
+                if key_type == "apikey":
+                    session_id = parts[2] if len(parts) > 2 else "default"
+                    await self._credentials_db.delete_api_key(provider, session_id)
+                elif key_type == "oauth":
+                    customer_id = parts[2] if len(parts) > 2 else "owner"
+                    await self._credentials_db.delete_oauth_tokens(provider, customer_id)
+                return True
+            else:
+                await self._credentials_db.delete_api_key(key, "default")
+                return True
+        except Exception as e:
+            logger.error(f"FernetBackend delete failed: {e}")
+            return False
+
+    def is_available(self) -> bool:
+        """Fernet backend is always available."""
+        return True
+
+
+class KeyringBackend(CredentialBackend):
+    """
+    OS-native credential storage using keyring library.
+
+    Uses:
+    - Windows: Credential Locker
+    - macOS: Keychain
+    - Linux: Secret Service (GNOME Keyring, KWallet)
+
+    Best for: Desktop deployments, single-user installations.
+    """
+
+    SERVICE_NAME = "MachinaOS"
+
+    def __init__(self):
+        self._keyring = None
+        self._available = False
+        try:
+            import keyring
+            self._keyring = keyring
+            # Test if keyring is working
+            self._keyring.get_password(self.SERVICE_NAME, "__test__")
+            self._available = True
+            logger.info("KeyringBackend initialized successfully")
+        except ImportError:
+            logger.warning("keyring library not installed, KeyringBackend unavailable")
+        except Exception as e:
+            logger.warning(f"keyring not working: {e}")
+
+    async def store(self, key: str, value: str, metadata: Optional[Dict[str, Any]] = None) -> bool:
+        """Store credential in OS keyring."""
+        if not self._available:
+            return False
+        try:
+            # Store value
+            self._keyring.set_password(self.SERVICE_NAME, key, value)
+            # Store metadata separately if provided
+            if metadata:
+                self._keyring.set_password(
+                    self.SERVICE_NAME,
+                    f"{key}__metadata",
+                    json.dumps(metadata)
+                )
+            return True
+        except Exception as e:
+            logger.error(f"KeyringBackend store failed: {e}")
+            return False
+
+    async def retrieve(self, key: str) -> Optional[str]:
+        """Retrieve credential from OS keyring."""
+        if not self._available:
+            return None
+        try:
+            return self._keyring.get_password(self.SERVICE_NAME, key)
+        except Exception as e:
+            logger.error(f"KeyringBackend retrieve failed: {e}")
+            return None
+
+    async def delete(self, key: str) -> bool:
+        """Delete credential from OS keyring."""
+        if not self._available:
+            return False
+        try:
+            self._keyring.delete_password(self.SERVICE_NAME, key)
+            # Also delete metadata if exists
+            try:
+                self._keyring.delete_password(self.SERVICE_NAME, f"{key}__metadata")
+            except Exception:
+                pass  # Metadata may not exist
+            return True
+        except Exception as e:
+            logger.error(f"KeyringBackend delete failed: {e}")
+            return False
+
+    def is_available(self) -> bool:
+        """Check if keyring is available."""
+        return self._available
+
+
+class AWSSecretsBackend(CredentialBackend):
+    """
+    AWS Secrets Manager backend for cloud production deployments.
+
+    Requires:
+    - boto3 library
+    - AWS credentials configured (IAM role, env vars, or ~/.aws/credentials)
+    - aws_secret_arn setting configured
+
+    Best for: AWS production deployments, multi-instance applications.
+    """
+
+    def __init__(self, secret_arn: Optional[str] = None, region: Optional[str] = None):
+        self._client = None
+        self._secret_arn = secret_arn
+        self._region = region or "us-east-1"
+        self._available = False
+        self._cache: Dict[str, str] = {}  # Local cache for performance
+
+        if not secret_arn:
+            logger.debug("AWSSecretsBackend: No secret_arn configured")
+            return
+
+        try:
+            import boto3
+            self._client = boto3.client("secretsmanager", region_name=self._region)
+            # Test connection
+            self._client.describe_secret(SecretId=self._secret_arn)
+            self._available = True
+            logger.info(f"AWSSecretsBackend initialized with secret: {self._secret_arn}")
+        except ImportError:
+            logger.warning("boto3 library not installed, AWSSecretsBackend unavailable")
+        except Exception as e:
+            logger.warning(f"AWS Secrets Manager not accessible: {e}")
+
+    async def store(self, key: str, value: str, metadata: Optional[Dict[str, Any]] = None) -> bool:
+        """Store credential in AWS Secrets Manager."""
+        if not self._available:
+            return False
+        try:
+            # Get current secret value
+            current = await self._get_all_secrets()
+
+            # Update with new key
+            current[key] = value
+            if metadata:
+                current[f"{key}__metadata"] = json.dumps(metadata)
+
+            # Put updated secret
+            self._client.put_secret_value(
+                SecretId=self._secret_arn,
+                SecretString=json.dumps(current)
+            )
+
+            # Update cache
+            self._cache[key] = value
+            return True
+        except Exception as e:
+            logger.error(f"AWSSecretsBackend store failed: {e}")
+            return False
+
+    async def retrieve(self, key: str) -> Optional[str]:
+        """Retrieve credential from AWS Secrets Manager."""
+        if not self._available:
+            return None
+
+        # Check cache first
+        if key in self._cache:
+            return self._cache[key]
+
+        try:
+            secrets = await self._get_all_secrets()
+            value = secrets.get(key)
+            if value:
+                self._cache[key] = value
+            return value
+        except Exception as e:
+            logger.error(f"AWSSecretsBackend retrieve failed: {e}")
+            return None
+
+    async def delete(self, key: str) -> bool:
+        """Delete credential from AWS Secrets Manager."""
+        if not self._available:
+            return False
+        try:
+            current = await self._get_all_secrets()
+
+            # Remove key and metadata
+            current.pop(key, None)
+            current.pop(f"{key}__metadata", None)
+
+            # Put updated secret
+            self._client.put_secret_value(
+                SecretId=self._secret_arn,
+                SecretString=json.dumps(current)
+            )
+
+            # Update cache
+            self._cache.pop(key, None)
+            return True
+        except Exception as e:
+            logger.error(f"AWSSecretsBackend delete failed: {e}")
+            return False
+
+    async def _get_all_secrets(self) -> Dict[str, str]:
+        """Get all secrets as a dictionary."""
+        try:
+            response = self._client.get_secret_value(SecretId=self._secret_arn)
+            return json.loads(response.get("SecretString", "{}"))
+        except Exception:
+            return {}
+
+    def is_available(self) -> bool:
+        """Check if AWS Secrets Manager is available."""
+        return self._available
+
+
+def create_backend(settings, credentials_db=None) -> CredentialBackend:
+    """
+    Factory function to create the appropriate credential backend.
+
+    Priority:
+    1. Use explicitly configured backend from settings.credential_backend
+    2. Auto-detect available backends with fallback to Fernet
+
+    Args:
+        settings: Application settings with credential_backend, aws_secret_arn, etc.
+        credentials_db: CredentialsDatabase instance (required for Fernet backend)
+
+    Returns:
+        Configured CredentialBackend instance
+    """
+    backend_type = getattr(settings, "credential_backend", "fernet").lower()
+
+    if backend_type == "aws":
+        aws_arn = getattr(settings, "aws_secret_arn", None)
+        aws_region = getattr(settings, "aws_region", None)
+        backend = AWSSecretsBackend(secret_arn=aws_arn, region=aws_region)
+        if backend.is_available():
+            logger.info("Using AWSSecretsBackend for credential storage")
+            return backend
+        logger.warning("AWS Secrets Manager not available, falling back to Fernet")
+
+    elif backend_type == "keyring":
+        backend = KeyringBackend()
+        if backend.is_available():
+            logger.info("Using KeyringBackend for credential storage")
+            return backend
+        logger.warning("OS Keyring not available, falling back to Fernet")
+
+    # Default: Fernet backend
+    if credentials_db is None:
+        raise ValueError("credentials_db required for Fernet backend")
+
+    logger.info("Using FernetBackend for credential storage")
+    return FernetBackend(credentials_db)

--- a/server/core/credentials_database.py
+++ b/server/core/credentials_database.py
@@ -1,0 +1,490 @@
+"""Separate encrypted database for API keys and OAuth tokens.
+
+This module provides a dedicated SQLite database for storing sensitive credentials
+with field-level Fernet encryption. Credentials are encrypted before storage and
+decrypted on retrieval.
+
+The database is separate from the main application database (machina.db) to:
+1. Isolate sensitive data from application data
+2. Allow different backup/security policies
+3. Enable easier credential rotation and management
+"""
+
+import hashlib
+import logging
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import Column, JSON
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import Field, SQLModel, select
+
+from core.encryption import EncryptionService
+
+logger = logging.getLogger(__name__)
+
+
+# --- SQLModel Definitions ---
+
+
+class CredentialsMetadata(SQLModel, table=True):
+    """Stores encryption salt and other metadata."""
+
+    __tablename__ = "credentials_metadata"
+
+    key: str = Field(primary_key=True, max_length=50)
+    value: str = Field(max_length=500)
+
+
+class EncryptedAPIKey(SQLModel, table=True):
+    """API keys with encrypted storage."""
+
+    __tablename__ = "api_keys"
+
+    id: str = Field(primary_key=True, max_length=255)  # {session_id}_{provider}
+    provider: str = Field(max_length=50, index=True)
+    session_id: str = Field(default="default", max_length=255)
+    key_encrypted: str = Field(max_length=2000)  # Fernet token
+    key_hash: str = Field(max_length=64, index=True)  # SHA256[:16] for lookup
+    models: Optional[Dict[str, Any]] = Field(default=None, sa_column=Column(JSON))
+    is_valid: bool = Field(default=True)
+    last_validated: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class EncryptedOAuthToken(SQLModel, table=True):
+    """OAuth tokens with encrypted storage."""
+
+    __tablename__ = "oauth_tokens"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    provider: str = Field(max_length=50, index=True)  # 'google', 'twitter'
+    customer_id: str = Field(default="owner", max_length=255, index=True)
+    email: Optional[str] = Field(default=None, max_length=255)
+    name: Optional[str] = Field(default=None, max_length=255)
+    access_token_encrypted: str = Field(max_length=4000)
+    refresh_token_encrypted: str = Field(max_length=4000)
+    token_expiry: Optional[datetime] = Field(default=None)
+    scopes: Optional[str] = Field(default=None, max_length=2000)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+# --- Database Class ---
+
+
+class CredentialsDatabase:
+    """
+    Async SQLite database with field-level Fernet encryption.
+
+    Provides secure storage for API keys and OAuth tokens in a separate
+    database file from the main application data.
+
+    Usage:
+        encryption = EncryptionService()
+        credentials_db = CredentialsDatabase("credentials.db", encryption)
+
+        # On app startup
+        salt = await credentials_db.initialize()
+
+        # On user login
+        encryption.initialize(password, salt)
+
+        # Store/retrieve credentials
+        await credentials_db.save_api_key("openai", "sk-xxx", ["gpt-4"])
+        api_key = await credentials_db.get_api_key("openai")
+    """
+
+    def __init__(self, db_path: str, encryption: EncryptionService):
+        """
+        Initialize credentials database.
+
+        Args:
+            db_path: Path to SQLite database file (e.g., "credentials.db")
+            encryption: EncryptionService instance for encrypt/decrypt operations
+        """
+        self.db_path = db_path
+        self.encryption = encryption
+        self.engine = create_async_engine(
+            f"sqlite+aiosqlite:///{db_path}",
+            echo=False,
+        )
+        self._session_factory = sessionmaker(
+            self.engine,
+            class_=AsyncSession,
+            expire_on_commit=False,
+        )
+        self._salt: Optional[bytes] = None
+
+    async def initialize(self) -> bytes:
+        """
+        Initialize database tables and return encryption salt.
+
+        Creates tables if they don't exist. Generates and stores a new salt
+        on first run, or retrieves existing salt on subsequent runs.
+
+        Returns:
+            Salt bytes for PBKDF2 key derivation
+        """
+        async with self.engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+        # Get or create salt
+        salt_hex = await self._get_metadata("encryption_salt")
+        if not salt_hex:
+            new_salt = EncryptionService.generate_salt()
+            await self._set_metadata("encryption_salt", new_salt.hex())
+            self._salt = new_salt
+            logger.info("Generated new encryption salt for credentials database")
+        else:
+            self._salt = bytes.fromhex(salt_hex)
+            logger.debug("Loaded existing encryption salt")
+
+        return self._salt
+
+    def get_salt(self) -> Optional[bytes]:
+        """Get cached salt (available after initialize())."""
+        return self._salt
+
+    @asynccontextmanager
+    async def get_session(self):
+        """Get async database session."""
+        async with self._session_factory() as session:
+            yield session
+
+    # --- Metadata Operations ---
+
+    async def _get_metadata(self, key: str) -> Optional[str]:
+        """Get metadata value by key."""
+        async with self.get_session() as session:
+            result = await session.execute(
+                select(CredentialsMetadata).where(CredentialsMetadata.key == key)
+            )
+            row = result.scalars().first()
+            return row.value if row else None
+
+    async def _set_metadata(self, key: str, value: str) -> None:
+        """Set metadata value."""
+        async with self.get_session() as session:
+            existing = await session.execute(
+                select(CredentialsMetadata).where(CredentialsMetadata.key == key)
+            )
+            row = existing.scalars().first()
+            if row:
+                row.value = value
+            else:
+                session.add(CredentialsMetadata(key=key, value=value))
+            await session.commit()
+
+    # --- API Key Operations ---
+
+    async def save_api_key(
+        self,
+        provider: str,
+        api_key: str,
+        models: Optional[List[str]] = None,
+        session_id: str = "default",
+    ) -> None:
+        """
+        Save encrypted API key.
+
+        Args:
+            provider: Provider name (e.g., "openai", "anthropic")
+            api_key: Plaintext API key to encrypt and store
+            models: List of available models for this key
+            session_id: Session identifier (default: "default")
+        """
+        key_id = f"{session_id}_{provider}"
+        encrypted = self.encryption.encrypt(api_key)
+        key_hash = hashlib.sha256(api_key.encode()).hexdigest()[:16]
+
+        async with self.get_session() as session:
+            existing = await session.get(EncryptedAPIKey, key_id)
+            now = datetime.now(timezone.utc)
+
+            if existing:
+                existing.key_encrypted = encrypted
+                existing.key_hash = key_hash
+                existing.models = {"models": models or []}
+                existing.is_valid = True
+                existing.last_validated = now
+                existing.updated_at = now
+            else:
+                session.add(
+                    EncryptedAPIKey(
+                        id=key_id,
+                        provider=provider,
+                        session_id=session_id,
+                        key_encrypted=encrypted,
+                        key_hash=key_hash,
+                        models={"models": models or []},
+                        is_valid=True,
+                        last_validated=now,
+                    )
+                )
+            await session.commit()
+            logger.debug(f"Saved encrypted API key for provider: {provider}")
+
+    async def get_api_key(
+        self, provider: str, session_id: str = "default"
+    ) -> Optional[str]:
+        """
+        Get decrypted API key.
+
+        Args:
+            provider: Provider name
+            session_id: Session identifier
+
+        Returns:
+            Decrypted API key or None if not found
+        """
+        key_id = f"{session_id}_{provider}"
+        async with self.get_session() as session:
+            row = await session.get(EncryptedAPIKey, key_id)
+            if not row:
+                return None
+            try:
+                return self.encryption.decrypt(row.key_encrypted)
+            except ValueError as e:
+                logger.error(f"Failed to decrypt API key for {provider}: {e}")
+                return None
+
+    async def get_api_key_info(
+        self, provider: str, session_id: str = "default"
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Get API key metadata (without decrypting the key).
+
+        Args:
+            provider: Provider name
+            session_id: Session identifier
+
+        Returns:
+            Dict with models, is_valid, last_validated, or None if not found
+        """
+        key_id = f"{session_id}_{provider}"
+        async with self.get_session() as session:
+            row = await session.get(EncryptedAPIKey, key_id)
+            if not row:
+                return None
+            return {
+                "provider": row.provider,
+                "models": row.models.get("models", []) if row.models else [],
+                "is_valid": row.is_valid,
+                "last_validated": row.last_validated,
+            }
+
+    async def delete_api_key(
+        self, provider: str, session_id: str = "default"
+    ) -> bool:
+        """
+        Delete API key.
+
+        Args:
+            provider: Provider name
+            session_id: Session identifier
+
+        Returns:
+            True if key was deleted, False if not found
+        """
+        key_id = f"{session_id}_{provider}"
+        async with self.get_session() as session:
+            row = await session.get(EncryptedAPIKey, key_id)
+            if row:
+                await session.delete(row)
+                await session.commit()
+                logger.debug(f"Deleted API key for provider: {provider}")
+                return True
+            return False
+
+    async def list_api_keys(self, session_id: str = "default") -> List[str]:
+        """
+        List all stored provider names for a session.
+
+        Args:
+            session_id: Session identifier
+
+        Returns:
+            List of provider names
+        """
+        async with self.get_session() as session:
+            result = await session.execute(
+                select(EncryptedAPIKey.provider).where(
+                    EncryptedAPIKey.session_id == session_id
+                )
+            )
+            return [row[0] for row in result.all()]
+
+    async def get_api_key_models(
+        self, provider: str, session_id: str = "default"
+    ) -> List[str]:
+        """
+        Get stored models for an API key.
+
+        Args:
+            provider: Provider name
+            session_id: Session identifier
+
+        Returns:
+            List of model names or empty list if not found
+        """
+        key_id = f"{session_id}_{provider}"
+        async with self.get_session() as session:
+            row = await session.get(EncryptedAPIKey, key_id)
+            if not row or not row.models:
+                return []
+            return row.models.get("models", [])
+
+    # --- OAuth Token Operations ---
+
+    async def save_oauth_tokens(
+        self,
+        provider: str,
+        access_token: str,
+        refresh_token: str,
+        email: Optional[str] = None,
+        name: Optional[str] = None,
+        expiry: Optional[datetime] = None,
+        scopes: Optional[str] = None,
+        customer_id: str = "owner",
+    ) -> None:
+        """
+        Save encrypted OAuth tokens.
+
+        Args:
+            provider: OAuth provider (e.g., "google", "twitter")
+            access_token: OAuth access token
+            refresh_token: OAuth refresh token
+            email: User email from OAuth provider
+            name: User display name
+            expiry: Token expiration datetime
+            scopes: Comma-separated granted scopes
+            customer_id: Customer identifier (default: "owner")
+        """
+        encrypted_access = self.encryption.encrypt(access_token)
+        encrypted_refresh = self.encryption.encrypt(refresh_token)
+
+        async with self.get_session() as session:
+            existing = await session.execute(
+                select(EncryptedOAuthToken).where(
+                    EncryptedOAuthToken.provider == provider,
+                    EncryptedOAuthToken.customer_id == customer_id,
+                )
+            )
+            row = existing.scalars().first()
+            now = datetime.now(timezone.utc)
+
+            if row:
+                row.access_token_encrypted = encrypted_access
+                row.refresh_token_encrypted = encrypted_refresh
+                row.email = email
+                row.name = name
+                row.token_expiry = expiry
+                row.scopes = scopes
+                row.updated_at = now
+            else:
+                session.add(
+                    EncryptedOAuthToken(
+                        provider=provider,
+                        customer_id=customer_id,
+                        email=email,
+                        name=name,
+                        access_token_encrypted=encrypted_access,
+                        refresh_token_encrypted=encrypted_refresh,
+                        token_expiry=expiry,
+                        scopes=scopes,
+                    )
+                )
+            await session.commit()
+            logger.debug(f"Saved encrypted OAuth tokens for provider: {provider}")
+
+    async def get_oauth_tokens(
+        self, provider: str, customer_id: str = "owner"
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Get decrypted OAuth tokens.
+
+        Args:
+            provider: OAuth provider
+            customer_id: Customer identifier
+
+        Returns:
+            Dict with access_token, refresh_token, email, name, etc.
+            or None if not found
+        """
+        async with self.get_session() as session:
+            result = await session.execute(
+                select(EncryptedOAuthToken).where(
+                    EncryptedOAuthToken.provider == provider,
+                    EncryptedOAuthToken.customer_id == customer_id,
+                )
+            )
+            row = result.scalars().first()
+            if not row:
+                return None
+
+            try:
+                return {
+                    "access_token": self.encryption.decrypt(row.access_token_encrypted),
+                    "refresh_token": self.encryption.decrypt(
+                        row.refresh_token_encrypted
+                    ),
+                    "email": row.email,
+                    "name": row.name,
+                    "token_expiry": row.token_expiry,
+                    "scopes": row.scopes,
+                }
+            except ValueError as e:
+                logger.error(f"Failed to decrypt OAuth tokens for {provider}: {e}")
+                return None
+
+    async def delete_oauth_tokens(
+        self, provider: str, customer_id: str = "owner"
+    ) -> bool:
+        """
+        Delete OAuth tokens.
+
+        Args:
+            provider: OAuth provider
+            customer_id: Customer identifier
+
+        Returns:
+            True if tokens were deleted, False if not found
+        """
+        async with self.get_session() as session:
+            result = await session.execute(
+                select(EncryptedOAuthToken).where(
+                    EncryptedOAuthToken.provider == provider,
+                    EncryptedOAuthToken.customer_id == customer_id,
+                )
+            )
+            row = result.scalars().first()
+            if row:
+                await session.delete(row)
+                await session.commit()
+                logger.debug(f"Deleted OAuth tokens for provider: {provider}")
+                return True
+            return False
+
+    async def list_oauth_providers(self, customer_id: str = "owner") -> List[str]:
+        """
+        List all OAuth providers with stored tokens.
+
+        Args:
+            customer_id: Customer identifier
+
+        Returns:
+            List of provider names
+        """
+        async with self.get_session() as session:
+            result = await session.execute(
+                select(EncryptedOAuthToken.provider).where(
+                    EncryptedOAuthToken.customer_id == customer_id
+                )
+            )
+            return [row[0] for row in result.all()]

--- a/server/core/encryption.py
+++ b/server/core/encryption.py
@@ -1,0 +1,151 @@
+"""Field-level encryption using Fernet (AES-128-CBC + HMAC-SHA256).
+
+This module provides secure encryption for API keys and OAuth tokens stored in
+the credentials database. Uses PBKDF2HMAC for key derivation from user password.
+
+Security:
+- Fernet: AES-128-CBC with PKCS7 padding + HMAC-SHA256 for authentication
+- PBKDF2: SHA256, 600,000 iterations (OWASP 2024 recommendation)
+- Key derived from user's login password, stored only in memory
+"""
+
+import base64
+import logging
+import os
+from typing import Optional
+
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+logger = logging.getLogger(__name__)
+
+
+class EncryptionService:
+    """
+    Fernet-based encryption service with key derivation from user password.
+
+    The encryption key is derived from the user's login password using PBKDF2
+    and stored only in memory. The key is cleared on logout.
+
+    Usage:
+        encryption = EncryptionService()
+        salt = await credentials_db.get_or_create_salt()
+        encryption.initialize(user_password, salt)
+
+        encrypted = encryption.encrypt("my-api-key")
+        decrypted = encryption.decrypt(encrypted)
+
+        encryption.clear()  # On logout
+    """
+
+    # OWASP recommended iterations for PBKDF2-SHA256 (2024)
+    PBKDF2_ITERATIONS = 600_000
+    SALT_LENGTH = 32  # 256 bits
+
+    def __init__(self):
+        self._fernet: Optional[Fernet] = None
+        self._salt: Optional[bytes] = None
+
+    def derive_key_from_password(self, password: str, salt: bytes) -> bytes:
+        """
+        Derive Fernet-compatible key from password using PBKDF2.
+
+        Args:
+            password: User's login password
+            salt: Random salt (should be stored in credentials DB)
+
+        Returns:
+            Base64-encoded 32-byte key suitable for Fernet
+        """
+        kdf = PBKDF2HMAC(
+            algorithm=hashes.SHA256(),
+            length=32,  # Fernet uses 32-byte keys
+            salt=salt,
+            iterations=self.PBKDF2_ITERATIONS,
+        )
+        key = kdf.derive(password.encode())
+        # Fernet requires URL-safe base64-encoded key
+        return base64.urlsafe_b64encode(key)
+
+    def initialize(self, password: str, salt: bytes) -> None:
+        """
+        Initialize Fernet cipher with key derived from password.
+
+        Must be called after successful user login before any encrypt/decrypt
+        operations. The derived key is stored only in memory.
+
+        Args:
+            password: User's login password (plaintext)
+            salt: Random salt from credentials database
+        """
+        key = self.derive_key_from_password(password, salt)
+        self._fernet = Fernet(key)
+        self._salt = salt
+        logger.debug("Encryption service initialized")
+
+    def encrypt(self, plaintext: str) -> str:
+        """
+        Encrypt string using Fernet.
+
+        Args:
+            plaintext: Data to encrypt (e.g., API key)
+
+        Returns:
+            Base64-encoded Fernet token (ciphertext)
+
+        Raises:
+            RuntimeError: If encryption service not initialized
+        """
+        if not self._fernet:
+            raise RuntimeError("Encryption service not initialized - user must be logged in")
+        token = self._fernet.encrypt(plaintext.encode())
+        return token.decode()  # Fernet tokens are already base64
+
+    def decrypt(self, ciphertext: str) -> str:
+        """
+        Decrypt Fernet token to plaintext string.
+
+        Args:
+            ciphertext: Base64-encoded Fernet token
+
+        Returns:
+            Decrypted plaintext string
+
+        Raises:
+            RuntimeError: If encryption service not initialized
+            ValueError: If decryption fails (wrong key or corrupted data)
+        """
+        if not self._fernet:
+            raise RuntimeError("Encryption service not initialized - user must be logged in")
+        try:
+            plaintext = self._fernet.decrypt(ciphertext.encode())
+            return plaintext.decode()
+        except InvalidToken as e:
+            logger.error("Decryption failed - invalid key or corrupted data")
+            raise ValueError("Decryption failed - invalid key or corrupted data") from e
+
+    def is_initialized(self) -> bool:
+        """Check if encryption service is ready for use."""
+        return self._fernet is not None
+
+    def clear(self) -> None:
+        """
+        Clear encryption key from memory.
+
+        Should be called on user logout to ensure keys don't persist
+        in memory longer than necessary.
+        """
+        self._fernet = None
+        self._salt = None
+        logger.debug("Encryption service cleared")
+
+    @staticmethod
+    def generate_salt() -> bytes:
+        """
+        Generate cryptographically secure random salt.
+
+        Returns:
+            32-byte random salt for PBKDF2 key derivation
+        """
+        return os.urandom(EncryptionService.SALT_LENGTH)

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = [
     "python-jose[cryptography]>=3.3.0",
     "email-validator>=2.0.0",
 
+    # Credential Encryption
+    "cryptography>=44.0.0",
+
     # AI - All providers (directly imported in ai.py)
     "langchain-core>=0.3.0",
     "langchain-openai>=0.2.0",
@@ -79,6 +82,12 @@ extra-ai = [
 docs = [
     "beautifulsoup4>=4.12.0",
     "pypdf>=5.0.0",
+]
+keyring = [
+    "keyring>=25.0.0",  # OS-native credential storage (Windows/macOS/Linux)
+]
+aws = [
+    "boto3>=1.34.0",  # AWS Secrets Manager
 ]
 
 [tool.uv]

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -68,6 +68,11 @@ bcrypt>=4.1.0
 python-jose[cryptography]>=3.3.0
 email-validator>=2.0.0
 
+# Credential Encryption & Storage
+cryptography>=44.0.0  # Fernet encryption (base backend)
+keyring>=25.0.0       # OS-native credential storage (optional desktop backend)
+# boto3>=1.34.0       # AWS Secrets Manager (optional cloud backend)
+
 # Timezone support
 pytz>=2024.1
 

--- a/server/services/auth.py
+++ b/server/services/auth.py
@@ -1,98 +1,114 @@
-"""Simple API key management service."""
+"""API key management service with encrypted credentials database."""
 
 import hashlib
-import base64
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, Optional, List
 
 from core.config import Settings
 from core.database import Database
 from core.cache import CacheService
+from core.credentials_database import CredentialsDatabase
 from core.logging import get_logger
 
 logger = get_logger(__name__)
 
 
 class AuthService:
-    """Simple API key management service."""
+    """API key management service using encrypted credentials database.
 
-    def __init__(self, database: Database, cache: CacheService, settings: Settings):
-        self.database = database
-        self.cache = cache
+    Uses CredentialsDatabase for secure storage with Fernet encryption.
+    Decrypted keys are cached in memory only (not Redis) for security.
+    """
+
+    def __init__(
+        self,
+        credentials_db: CredentialsDatabase,
+        cache: CacheService,
+        database: Database,
+        settings: Settings
+    ):
+        self.credentials_db = credentials_db
+        self.cache = cache  # Kept for backward compatibility, not used for API keys
+        self.database = database  # Kept for backward compatibility
         self.settings = settings
-
-    def encrypt_api_key(self, api_key: str) -> str:
-        """Simple base64 encoding (compatible with frontend)."""
-        return base64.b64encode(api_key.encode()).decode()
-
-    def decrypt_api_key(self, encrypted_key: str) -> str:
-        """Simple base64 decoding."""
-        try:
-            return base64.b64decode(encrypted_key.encode()).decode()
-        except Exception:
-            return ""
+        # Memory-only cache for decrypted API keys (never persisted to Redis/disk)
+        self._memory_cache: Dict[str, str] = {}
+        # Memory-only cache for models list
+        self._models_cache: Dict[str, List[str]] = {}
+        # Memory-only cache for OAuth tokens
+        self._oauth_cache: Dict[str, Dict[str, Any]] = {}
 
     def hash_api_key(self, api_key: str) -> str:
         """Create hash for API key identification."""
         return hashlib.sha256(api_key.encode()).hexdigest()[:16]
 
-    async def store_api_key(self, provider: str, api_key: str, models: List[str],
-                          session_id: str = "default") -> bool:
-        """Store API key with models."""
+    async def store_api_key(
+        self,
+        provider: str,
+        api_key: str,
+        models: List[str],
+        session_id: str = "default"
+    ) -> bool:
+        """Store API key with models in encrypted credentials database.
+
+        Args:
+            provider: API provider name (e.g., 'openai', 'anthropic')
+            api_key: The API key to store (will be encrypted)
+            models: List of available models for this key
+            session_id: Session identifier for multi-user support
+
+        Returns:
+            True if stored successfully, False otherwise
+        """
         try:
-            key_id = f"{session_id}_{provider}"
-            encrypted_key = self.encrypt_api_key(api_key)
-            key_hash = self.hash_api_key(api_key)
+            cache_key = f"{session_id}_{provider}"
 
-            logger.info(f"Storing API key for provider: {provider}, session: {session_id}, key_id: {key_id}")
+            logger.info(f"Storing API key for provider: {provider}, session: {session_id}")
 
-            # Store in database
-            success = await self.database.save_api_key(
-                key_id=key_id,
+            # Store in encrypted credentials database
+            await self.credentials_db.save_api_key(
                 provider=provider,
-                session_id=session_id,
-                key_encrypted=encrypted_key,
-                key_hash=key_hash,
-                models=models
+                api_key=api_key,
+                models=models,
+                session_id=session_id
             )
 
-            logger.info(f"Database save result: {success}")
+            # Cache decrypted key in memory only (for quick access)
+            self._memory_cache[cache_key] = api_key
+            self._models_cache[cache_key] = models
 
-            # Cache for quick access
-            if success:
-                cache_data = {
-                    "encrypted_key": encrypted_key,
-                    "models": models,
-                    "last_validated": datetime.utcnow().isoformat()
-                }
-                await self.cache.cache_api_key(provider, session_id, cache_data)
-                logger.info(f"Cached API key for {provider}")
-
-            return success
+            logger.info(f"Stored and cached API key for {provider}")
+            return True
 
         except Exception as e:
             logger.error("Failed to store API key", provider=provider, error=str(e))
             return False
 
     async def get_api_key(self, provider: str, session_id: str = "default") -> Optional[str]:
-        """Get decrypted API key."""
-        try:
-            # Try cache first
-            cached_data = await self.cache.get_cached_api_key(provider, session_id)
-            if cached_data:
-                return self.decrypt_api_key(cached_data["encrypted_key"])
+        """Get decrypted API key.
 
-            # Fallback to database
-            api_key_record = await self.database.get_api_key_by_provider(provider, session_id)
-            if api_key_record and api_key_record.is_valid:
-                # Check if not expired (30 days)
-                # Ensure both datetimes are timezone-aware for comparison
-                # SQLite may return offset-naive datetimes
-                last_validated = api_key_record.last_validated
-                if last_validated.tzinfo is None:
-                    last_validated = last_validated.replace(tzinfo=timezone.utc)
-                if datetime.now(timezone.utc) - last_validated < timedelta(days=30):
-                    return self.decrypt_api_key(api_key_record.key_encrypted)
+        Checks memory cache first, then falls back to encrypted database.
+
+        Args:
+            provider: API provider name
+            session_id: Session identifier
+
+        Returns:
+            Decrypted API key or None if not found/expired
+        """
+        try:
+            cache_key = f"{session_id}_{provider}"
+
+            # Check memory cache first (fastest, most secure)
+            if cache_key in self._memory_cache:
+                return self._memory_cache[cache_key]
+
+            # Fallback to encrypted database
+            api_key = await self.credentials_db.get_api_key(provider, session_id)
+            if api_key:
+                # Cache in memory for quick subsequent access
+                self._memory_cache[cache_key] = api_key
+                return api_key
 
             return None
 
@@ -101,17 +117,27 @@ class AuthService:
             return None
 
     async def get_stored_models(self, provider: str, session_id: str = "default") -> List[str]:
-        """Get stored models for provider."""
-        try:
-            # Try cache first
-            cached_data = await self.cache.get_cached_api_key(provider, session_id)
-            if cached_data and cached_data.get("models"):
-                return cached_data["models"]
+        """Get stored models for provider.
 
-            # Fallback to database
-            api_key_record = await self.database.get_api_key_by_provider(provider, session_id)
-            if api_key_record and api_key_record.models:
-                return api_key_record.models.get("models", [])
+        Args:
+            provider: API provider name
+            session_id: Session identifier
+
+        Returns:
+            List of model names or empty list
+        """
+        try:
+            cache_key = f"{session_id}_{provider}"
+
+            # Check memory cache first
+            if cache_key in self._models_cache:
+                return self._models_cache[cache_key]
+
+            # Fallback to encrypted database
+            models = await self.credentials_db.get_api_key_models(provider, session_id)
+            if models:
+                self._models_cache[cache_key] = models
+                return models
 
             return []
 
@@ -120,17 +146,170 @@ class AuthService:
             return []
 
     async def remove_api_key(self, provider: str, session_id: str = "default") -> bool:
-        """Remove API key."""
+        """Remove API key from storage and cache.
+
+        Args:
+            provider: API provider name
+            session_id: Session identifier
+
+        Returns:
+            True if removed successfully
+        """
         try:
-            # Remove from cache and database
-            await self.cache.remove_cached_api_key(provider, session_id)
-            return await self.database.delete_api_key(provider, session_id)
+            cache_key = f"{session_id}_{provider}"
+
+            # Remove from memory cache
+            self._memory_cache.pop(cache_key, None)
+            self._models_cache.pop(cache_key, None)
+
+            # Remove from encrypted database
+            await self.credentials_db.delete_api_key(provider, session_id)
+
+            logger.info(f"Removed API key for {provider}")
+            return True
 
         except Exception as e:
             logger.error("Failed to remove API key", provider=provider, error=str(e))
             return False
 
     async def has_valid_key(self, provider: str, session_id: str = "default") -> bool:
-        """Check if valid API key exists."""
+        """Check if valid API key exists.
+
+        Args:
+            provider: API provider name
+            session_id: Session identifier
+
+        Returns:
+            True if a valid key exists
+        """
         api_key = await self.get_api_key(provider, session_id)
         return api_key is not None
+
+    def clear_cache(self) -> None:
+        """Clear all memory caches.
+
+        Should be called on user logout to ensure decrypted keys
+        don't persist in memory longer than necessary.
+        """
+        self._memory_cache.clear()
+        self._models_cache.clear()
+        self._oauth_cache.clear()
+        logger.debug("Cleared all credential memory caches")
+
+    # --- OAuth Token Methods ---
+
+    async def store_oauth_tokens(
+        self,
+        provider: str,
+        access_token: str,
+        refresh_token: str,
+        email: Optional[str] = None,
+        name: Optional[str] = None,
+        scopes: Optional[str] = None,
+        customer_id: str = "owner"
+    ) -> bool:
+        """Store OAuth tokens in encrypted credentials database.
+
+        Args:
+            provider: OAuth provider name (e.g., 'google', 'twitter')
+            access_token: OAuth access token
+            refresh_token: OAuth refresh token
+            email: User email or identifier
+            name: User display name
+            scopes: Comma-separated scopes
+            customer_id: Customer identifier (default 'owner' for single-user)
+
+        Returns:
+            True if stored successfully
+        """
+        try:
+            cache_key = f"{customer_id}_{provider}"
+
+            await self.credentials_db.save_oauth_tokens(
+                provider=provider,
+                access_token=access_token,
+                refresh_token=refresh_token,
+                email=email,
+                name=name,
+                scopes=scopes,
+                customer_id=customer_id
+            )
+
+            # Cache in memory
+            self._oauth_cache[cache_key] = {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "email": email,
+                "name": name,
+                "scopes": scopes
+            }
+
+            logger.info(f"Stored OAuth tokens for {provider}")
+            return True
+
+        except Exception as e:
+            logger.error("Failed to store OAuth tokens", provider=provider, error=str(e))
+            return False
+
+    async def get_oauth_tokens(
+        self,
+        provider: str,
+        customer_id: str = "owner"
+    ) -> Optional[Dict[str, Any]]:
+        """Get OAuth tokens from cache or encrypted database.
+
+        Args:
+            provider: OAuth provider name
+            customer_id: Customer identifier
+
+        Returns:
+            Dict with access_token, refresh_token, email, name, scopes or None
+        """
+        try:
+            cache_key = f"{customer_id}_{provider}"
+
+            # Check memory cache first
+            if cache_key in self._oauth_cache:
+                return self._oauth_cache[cache_key]
+
+            # Fallback to encrypted database
+            tokens = await self.credentials_db.get_oauth_tokens(provider, customer_id)
+            if tokens:
+                self._oauth_cache[cache_key] = tokens
+                return tokens
+
+            return None
+
+        except Exception as e:
+            logger.error("Failed to get OAuth tokens", provider=provider, error=str(e))
+            return None
+
+    async def remove_oauth_tokens(
+        self,
+        provider: str,
+        customer_id: str = "owner"
+    ) -> bool:
+        """Remove OAuth tokens from storage and cache.
+
+        Args:
+            provider: OAuth provider name
+            customer_id: Customer identifier
+
+        Returns:
+            True if removed successfully
+        """
+        try:
+            cache_key = f"{customer_id}_{provider}"
+
+            # Remove from memory cache
+            self._oauth_cache.pop(cache_key, None)
+
+            # Remove from encrypted database
+            await self.credentials_db.delete_oauth_tokens(provider, customer_id)
+
+            logger.info(f"Removed OAuth tokens for {provider}")
+            return True
+
+        except Exception as e:
+            logger.error("Failed to remove OAuth tokens", provider=provider, error=str(e))
+            return False

--- a/server/services/user_auth.py
+++ b/server/services/user_auth.py
@@ -1,4 +1,4 @@
-"""User authentication service with JWT handling."""
+"""User authentication service with JWT handling and encryption initialization."""
 
 import logging
 from datetime import datetime, timezone, timedelta
@@ -9,17 +9,32 @@ from sqlmodel import select
 
 from core.config import Settings
 from core.database import Database
+from core.encryption import EncryptionService
+from core.credentials_database import CredentialsDatabase
 from models.auth import User
 
 logger = logging.getLogger(__name__)
 
 
 class UserAuthService:
-    """Handles user authentication, registration, and JWT token management."""
+    """Handles user authentication, registration, and JWT token management.
 
-    def __init__(self, database: Database, settings: Settings):
+    On login, this service initializes the EncryptionService with a key derived
+    from the user's password. This enables decryption of API keys and OAuth tokens
+    stored in the separate credentials database.
+    """
+
+    def __init__(
+        self,
+        database: Database,
+        settings: Settings,
+        encryption: EncryptionService,
+        credentials_db: CredentialsDatabase,
+    ):
         self.database = database
         self.settings = settings
+        self.encryption = encryption
+        self.credentials_db = credentials_db
         self._algorithm = "HS256"
 
     async def get_user_count(self) -> int:
@@ -39,9 +54,7 @@ class UserAuthService:
     async def get_user_by_id(self, user_id: int) -> Optional[User]:
         """Get user by ID."""
         async with self.database.get_session() as session:
-            result = await session.execute(
-                select(User).where(User.id == user_id)
-            )
+            result = await session.execute(select(User).where(User.id == user_id))
             return result.scalars().first()
 
     async def can_register(self) -> bool:
@@ -75,14 +88,16 @@ class UserAuthService:
             return None, "Password must be at least 8 characters"
 
         # Determine if this is the owner (first user in single-owner mode)
-        is_owner = self.settings.auth_mode == "single" and await self.get_user_count() == 0
+        is_owner = (
+            self.settings.auth_mode == "single" and await self.get_user_count() == 0
+        )
 
         # Create user
         user = User.create(
             email=email,
             password=password,
             display_name=display_name,
-            is_owner=is_owner
+            is_owner=is_owner,
         )
 
         async with self.database.get_session() as session:
@@ -91,6 +106,11 @@ class UserAuthService:
             await session.refresh(user)
 
         logger.info(f"User registered: {email} (owner={is_owner})")
+
+        # Initialize encryption for the new user
+        # This ensures credentials can be saved immediately after registration
+        await self._initialize_encryption(password)
+
         return user, None
 
     async def login(
@@ -99,6 +119,9 @@ class UserAuthService:
         """
         Authenticate user and return user object.
         Returns (user, None) on success, (None, error_message) on failure.
+
+        On successful login, initializes the EncryptionService with a key
+        derived from the user's password for decrypting stored credentials.
         """
         user = await self.get_user_by_email(email)
         if not user:
@@ -112,29 +135,58 @@ class UserAuthService:
 
         # Update last login
         async with self.database.get_session() as session:
-            result = await session.execute(
-                select(User).where(User.id == user.id)
-            )
+            result = await session.execute(select(User).where(User.id == user.id))
             db_user = result.scalars().first()
             if db_user:
                 db_user.last_login = datetime.now(timezone.utc)
                 await session.commit()
 
+        # Initialize encryption with user's password
+        await self._initialize_encryption(password)
+
         logger.info(f"User logged in: {email}")
         return user, None
 
+    async def _initialize_encryption(self, password: str) -> None:
+        """
+        Initialize encryption service with key derived from password.
+
+        Gets or creates the salt from the credentials database and uses it
+        with the password to derive the encryption key via PBKDF2.
+        """
+        # Ensure credentials database is initialized and get salt
+        salt = await self.credentials_db.initialize()
+
+        # Initialize encryption service with derived key
+        self.encryption.initialize(password, salt)
+        logger.debug("Encryption service initialized for user session")
+
+    def logout(self) -> None:
+        """
+        Clear encryption key on logout.
+
+        Clears the encryption service's in-memory key to ensure credentials
+        cannot be decrypted after user logout.
+        """
+        self.encryption.clear()
+        logger.debug("Encryption service cleared on logout")
+
     def create_access_token(self, user: User) -> str:
         """Create JWT access token for user."""
-        expire = datetime.now(timezone.utc) + timedelta(minutes=self.settings.jwt_expire_minutes)
+        expire = datetime.now(timezone.utc) + timedelta(
+            minutes=self.settings.jwt_expire_minutes
+        )
         payload = {
             "sub": str(user.id),
             "email": user.email,
             "display_name": user.display_name,
             "is_owner": user.is_owner,
             "exp": expire,
-            "iat": datetime.now(timezone.utc)
+            "iat": datetime.now(timezone.utc),
         }
-        return jwt.encode(payload, self.settings.jwt_secret_key, algorithm=self._algorithm)
+        return jwt.encode(
+            payload, self.settings.jwt_secret_key, algorithm=self._algorithm
+        )
 
     def verify_token(self, token: str) -> Optional[Dict[str, Any]]:
         """
@@ -143,9 +195,7 @@ class UserAuthService:
         """
         try:
             payload = jwt.decode(
-                token,
-                self.settings.jwt_secret_key,
-                algorithms=[self._algorithm]
+                token, self.settings.jwt_secret_key, algorithms=[self._algorithm]
             )
             return payload
         except JWTError as e:
@@ -168,5 +218,9 @@ class UserAuthService:
         """Get authentication status and mode info."""
         return {
             "auth_mode": self.settings.auth_mode,
-            "registration_enabled": self.settings.auth_mode == "multi"
+            "registration_enabled": self.settings.auth_mode == "multi",
         }
+
+    def is_encryption_initialized(self) -> bool:
+        """Check if encryption is ready for use."""
+        return self.encryption.is_initialized()


### PR DESCRIPTION
- Add Fernet encryption for API keys and OAuth tokens (AES-128-CBC + HMAC-SHA256)
- Add PBKDF2 key derivation from user password (600k iterations, OWASP 2024)
- Create separate credentials.db for credential isolation
- Add multi-backend abstraction: Fernet (default), Keyring (OS-native), AWS Secrets Manager
- Update AuthService as single point of access for all credentials
- Update Google/Twitter routers to use auth_service instead of credentials_db directly
- Add credential_backend, aws_secret_arn, aws_region config settings