### PR TITLE
fix(distribution): publish OpenCompany as @zeenie/opencompany

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,14 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
       - run: python -m cli version sync
-      - run: npm publish --access public --provenance
+      - name: Verify npm credentials and scope access
+        run: |
+          npm whoami
+          npm access list packages @zeenie --json
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish public npm package
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to OpenCompany
 
-Welcome! This guide is a contributor's map to the codebase. It tells you *where things live* and *where to start reading* when you want to add a feature. For the full architecture tour, use the [DeepWiki badge](https://deepwiki.com/zeenie-ai/MachinaOS) on the README or browse [docs-internal/](docs-internal/).
+Welcome! This guide is a contributor's map to the codebase. It tells you *where things live* and *where to start reading* when you want to add a feature. For the full architecture tour, use the [DeepWiki badge](https://deepwiki.com/zeenie-ai/OpenCompany) on the README or browse [docs-internal/](docs-internal/).
 
 ## Contribution Workflow
 
@@ -13,7 +13,7 @@ See [SETUP.md](docs-internal/SETUP.md) for environment setup and [SCRIPTS.md](do
 
 ## System Overview
 
-[![System Overview](docs/diagrams/system-overview.svg)](https://raw.githubusercontent.com/zeenie-ai/MachinaOS/main/docs/diagrams/system-overview.svg)
+[![System Overview](docs/diagrams/system-overview.svg)](https://raw.githubusercontent.com/zeenie-ai/OpenCompany/main/docs/diagrams/system-overview.svg)
 
 At a glance:
 
@@ -26,7 +26,7 @@ At a glance:
 
 ## How Workflows Execute
 
-[![Execution Flow](docs/diagrams/execution-flow.svg)](https://raw.githubusercontent.com/zeenie-ai/MachinaOS/main/docs/diagrams/execution-flow.svg)
+[![Execution Flow](docs/diagrams/execution-flow.svg)](https://raw.githubusercontent.com/zeenie-ai/OpenCompany/main/docs/diagrams/execution-flow.svg)
 
 [WorkflowService](server/services/workflow.py) is a thin facade that routes each run through one of three execution modes. Every run has an isolated `ExecutionContext` with no shared global state, orchestrated by Conductor's decide pattern (`_workflow_decide` under a Redis `SETNX` lock). Layers are computed via Kahn's algorithm and each layer runs via `asyncio.gather()`. Results are cached by input hash (Prefect pattern), failed nodes go to a Dead Letter Queue, and a `RecoverySweeper` handles crashes via heartbeats.
 
@@ -34,7 +34,7 @@ Deep dives: [DESIGN.md](docs-internal/DESIGN.md) - [TEMPORAL_ARCHITECTURE.md](do
 
 ## AI Agent System
 
-[![AI Agent Routing](docs/diagrams/ai-agent-routing.svg)](https://raw.githubusercontent.com/zeenie-ai/MachinaOS/main/docs/diagrams/ai-agent-routing.svg)
+[![AI Agent Routing](docs/diagrams/ai-agent-routing.svg)](https://raw.githubusercontent.com/zeenie-ai/OpenCompany/main/docs/diagrams/ai-agent-routing.svg)
 
 AI execution splits into two paths. `execute_chat()` for direct chat completions prefers the native SDK layer in [services/llm/](server/services/llm/) (12 providers, lazy imports, normalized `LLMResponse`), falling back to LangChain for Groq and Cerebras. `execute_agent()` and `execute_chat_agent()` build a LangChain chat model (`ChatOpenAI` / `ChatAnthropic` / etc.) and drive it through `_run_agent_loop` — a plain async `for iteration in range(max):` that calls `chat_model.ainvoke`, dispatches any `tool_calls`, appends `ToolMessage` results, and loops. Team leads (`orchestrator_agent`, `ai_employee`) auto-inject `delegate_to_<type>` tools for every agent connected to their `input-teammates` handle. The RLM Agent uses a REPL-based recursive language model pattern. Long-running activities (browser automation, claude_code_agent) stay alive across Temporal's 2-minute heartbeat window via per-message `activity.heartbeat()` calls in the WebSocket read loop.
 
@@ -59,7 +59,7 @@ Deep dives: [agent_architecture.md](docs-internal/agent_architecture.md) - [nati
 
 ## How to Contribute Features
 
-[![Node Anatomy](docs/diagrams/node-anatomy.svg)](https://raw.githubusercontent.com/zeenie-ai/MachinaOS/main/docs/diagrams/node-anatomy.svg)
+[![Node Anatomy](docs/diagrams/node-anatomy.svg)](https://raw.githubusercontent.com/zeenie-ai/OpenCompany/main/docs/diagrams/node-anatomy.svg)
 
 The diagram above shows the full lifecycle of a workflow node from TypeScript definition to Python handler. Use these recipes as a starting point:
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 
 # OpenCompany
 
-<a href="https://www.npmjs.com/package/opencompany" target="_blank"><img src="https://img.shields.io/npm/v/opencompany.svg" alt="npm version"></a>
+<a href="https://www.npmjs.com/package/@zeenie/opencompany" target="_blank"><img src="https://img.shields.io/npm/v/%40zeenie%2Fopencompany.svg" alt="npm version"></a>
 <a href="https://opensource.org/licenses/MIT" target="_blank"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
 <a href="https://discord.gg/c9pCJ7d8Ce" target="_blank"><img src="https://img.shields.io/discord/1455977012308086895?logo=discord&logoColor=white&label=Discord" alt="Discord"></a>
-<a href="https://deepwiki.com/zeenie-ai/MachinaOS" target="_blank"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
+<a href="https://deepwiki.com/zeenie-ai/OpenCompany" target="_blank"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 
 Your own AI assistant that does real work. Drag, drop, and connect AI agents to your email, calendar, messages, phone, and 50+ other services. Runs on your own machine — your data stays with you.
 
@@ -17,9 +17,13 @@ No code required. No subscription. No usage limits. Bring your own API keys (or 
 **Prerequisites:** Node.js 22+, Python 3.12+
 
 ```bash
-npm install -g opencompany
+npm install -g @zeenie/opencompany
 company start
 ```
+
+The canonical npm package is `@zeenie/opencompany`. The unscoped
+`opencompany` package is unrelated to this project and is neither installed nor
+removed by OpenCompany's tooling.
 
 Open http://localhost:3000 and click **Credentials** to connect your first AI provider.
 
@@ -33,7 +37,7 @@ available as a deprecated legacy alias; new scripts should use `company`.
 
 ```bash
 npm install -g pnpm
-git clone https://github.com/zeenie-ai/MachinaOS.git OpenCompany
+git clone https://github.com/zeenie-ai/OpenCompany.git OpenCompany
 cd OpenCompany
 pnpm run build
 pnpm run dev
@@ -57,13 +61,13 @@ https://github.com/user-attachments/assets/5798fe61-8d26-4d3a-90aa-189bf4eec79f
 
 ## How It Works
 
-[![How OpenCompany Works](docs/diagrams/how-it-works.svg)](https://raw.githubusercontent.com/zeenie-ai/MachinaOS/main/docs/diagrams/how-it-works.svg)
+[![How OpenCompany Works](docs/diagrams/how-it-works.svg)](https://raw.githubusercontent.com/zeenie-ai/OpenCompany/main/docs/diagrams/how-it-works.svg)
 
 Pick nodes from the palette, drag them onto a canvas, connect them with lines, give your AI agent some memory and skills, and hit Play. Or **deploy** the workflow so it runs forever in the background — waiting for emails, responding to messages, checking in on a schedule, doing the work you'd rather not.
 
 ## Three Example Workflows For Reference.
 
-[![Default workflows that ship with OpenCompany](docs/diagrams/default-workflows.svg)](https://raw.githubusercontent.com/zeenie-ai/MachinaOS/main/docs/diagrams/default-workflows.svg)
+[![Default workflows that ship with OpenCompany](docs/diagrams/default-workflows.svg)](https://raw.githubusercontent.com/zeenie-ai/OpenCompany/main/docs/diagrams/default-workflows.svg)
 
 The first time you open OpenCompany, three example workflows load automatically. Open them on the canvas to see exactly how the pieces fit together, then edit any node and save your own version.
 
@@ -172,7 +176,7 @@ Every LLM call and API request is tracked with USD cost. See per-provider spend 
 
 ## Quick Setup Tour
 
-1. **Install** with `npm install -g opencompany` (or run from source)
+1. **Install** with `npm install -g @zeenie/opencompany` (or run from source)
 2. **Start** with `company start` — opens at http://localhost:3000
 3. **Connect a provider** — click the **Credentials** button, paste an API key or click through OAuth
 4. **Drag a node** from the left palette onto the canvas
@@ -190,7 +194,7 @@ Want to add a node, LLM provider, skill, or integration? One Python file = one n
 - **[docs-internal/](docs-internal/)** — deep-dive architecture docs (execution engine, Temporal, LLM layer, credentials, event system, performance, build pipeline)
 - **[CLAUDE.md](CLAUDE.md)** — comprehensive project memory (great for AI-assisted contributions)
 - **Hosted docs:** https://docs.zeenie.xyz/
-- **DeepWiki:** https://deepwiki.com/zeenie-ai/MachinaOS
+- **DeepWiki:** https://deepwiki.com/zeenie-ai/OpenCompany
 
 ## Community
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,7 +1,7 @@
 # company
 
 Project supervisor CLI for the OpenCompany stack. The public command is
-`company`; the npm package is `opencompany`, and the legacy `machina` bin
+`company`; the npm package is `@zeenie/opencompany`, and the legacy `machina` bin
 remains as a deprecated compatibility alias. It is also backwards-compatible
 with `pnpm run start`/`dev`/`stop`/etc.
 

--- a/cli/commands/build.py
+++ b/cli/commands/build.py
@@ -117,7 +117,7 @@ def build_command() -> None:
     #
     # Safe for global installs: ``.env.dev`` is committed to git for
     # repo-clone contributors but is NOT in the npm ``files`` list, so
-    # ``npm install -g opencompany`` doesn't ship it. Without
+    # ``npm install -g @zeenie/opencompany`` doesn't ship it. Without
     # ``.env.dev`` on disk, :func:`load_dev_overrides` is a no-op and
     # the build falls through to ``.env.template`` defaults
     # (``DATA_DIR=~/.opencompany``) — identical to today's behaviour and

--- a/cli/config.py
+++ b/cli/config.py
@@ -6,7 +6,7 @@ Stdlib-only env-var loader. Three env files, lowest precedence first:
      install. ``DATA_DIR=~/.opencompany`` (user home) is the daemon
      behaviour: ``company start`` / ``company daemon`` use these.
   2. ``.env`` — user overrides (created by ``scripts/postinstall.js`` on
-     ``npm install -g opencompany``). Gitignored.
+     ``npm install -g @zeenie/opencompany``). Gitignored.
   3. ``.env.dev`` — dev-mode overrides. Loaded ONLY by ``company dev``
      via :func:`load_dev_overrides`. Pins ``DATA_DIR=.opencompany`` so
      per-checkout dev state lives at ``<repo>/.opencompany/`` instead of
@@ -55,7 +55,7 @@ def _require(env: dict[str, str], key: str) -> str:
     if raw is None:
         raise KeyError(
             f"{key} missing from .env / .env.template -- "
-            "reinstall (``npm install -g opencompany``) or restore the template."
+            "reinstall (``npm install -g @zeenie/opencompany``) or restore the template."
         )
     return raw
 
@@ -143,7 +143,7 @@ def load_config(root: Path | None = None) -> Config:
     if not template.exists():
         raise FileNotFoundError(
             f".env.template not found at {template}. "
-            "Reinstall (``npm install -g opencompany``) or restore the template "
+            "Reinstall (``npm install -g @zeenie/opencompany``) or restore the template "
             "from the source tree."
         )
 

--- a/cli/terraform/gcp/startup.sh.tftpl
+++ b/cli/terraform/gcp/startup.sh.tftpl
@@ -21,12 +21,17 @@ corepack enable || true
 curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 
 echo "[${resource_name}] installing OpenCompany package..."
+# The pre-rebrand package owns the deprecated `machina` binary too. Remove it
+# first so npm can create OpenCompany's compatibility shim during an upgrade.
+if npm list -g --depth=0 machinaos >/dev/null 2>&1; then
+  npm uninstall -g machinaos
+fi
 %{ if source_mode == "local" ~}
 TOKEN=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" | python3 -c 'import sys, json; print(json.load(sys.stdin)["access_token"])')
 curl -fsS -H "Authorization: Bearer $TOKEN" -o /tmp/${resource_name}.tgz "https://storage.googleapis.com/storage/v1/b/${bucket}/o/${object}?alt=media"
 npm install -g /tmp/${resource_name}.tgz
 %{ else ~}
-npm install -g opencompany@${version}
+npm install -g @zeenie/opencompany@${version}
 %{ endif ~}
 
 echo "[${resource_name}] writing login-gate env..."

--- a/cli/tests/test_cli_branding.py
+++ b/cli/tests/test_cli_branding.py
@@ -14,7 +14,7 @@ ROOT = project_root()
 def test_npm_bins_expose_company_and_deprecated_machina_only():
     package = json.loads((ROOT / "package.json").read_text(encoding="utf-8"))
 
-    assert package["name"] == "opencompany"
+    assert package["name"] == "@zeenie/opencompany"
     assert package["bin"] == {
         "company": "./bin/cli.js",
         "machina": "./bin/machina.js",
@@ -39,10 +39,38 @@ def test_cloud_service_resolves_company_then_legacy_machina():
         encoding="utf-8"
     )
 
-    assert "npm install -g opencompany@${version}" in template
+    assert "npm install -g @zeenie/opencompany@${version}" in template
+    assert "npm uninstall -g machinaos" in template
     assert "command -v company || command -v machina" in template
     assert "command -v opencompany" not in template
     assert "ExecStart=$OPENCOMPANY_BIN serve" in template
+
+
+def test_installers_target_scoped_package_without_touching_unscoped_package():
+    installers = {
+        "install.sh": (ROOT / "install.sh").read_text(encoding="utf-8"),
+        "install.ps1": (ROOT / "install.ps1").read_text(encoding="utf-8"),
+        "gcp startup": (
+            ROOT / "cli" / "terraform" / "gcp" / "startup.sh.tftpl"
+        ).read_text(encoding="utf-8"),
+    }
+
+    assert "npm install -g '@zeenie/opencompany'" in installers["install.sh"]
+    assert 'npm install -g "@zeenie/opencompany"' in installers["install.ps1"]
+    assert "npm install -g @zeenie/opencompany@${version}" in installers["gcp startup"]
+
+    for source in installers.values():
+        assert "npm install -g opencompany" not in source
+        assert "npm uninstall -g opencompany" not in source
+        assert "npm uninstall -g machinaos" in source
+
+
+def test_uninstaller_removes_only_scoped_and_official_legacy_packages():
+    uninstaller = (ROOT / "uninstall.sh").read_text(encoding="utf-8")
+
+    assert "remove_global_package '@zeenie/opencompany'" in uninstaller
+    assert "remove_global_package 'machinaos'" in uninstaller
+    assert "npm uninstall -g opencompany" not in uninstaller
 
 
 def test_node_shims_print_canonical_name_and_deprecation_warning():

--- a/cli/tests/test_release_pipeline_config.py
+++ b/cli/tests/test_release_pipeline_config.py
@@ -84,6 +84,22 @@ def install_js_src(root: Path) -> str:
     return (root / "scripts" / "install.js").read_text(encoding="utf-8")
 
 
+@pytest.fixture(scope="module")
+def root_pkg(root: Path) -> dict:
+    return _load_pkg_json(root)
+
+
+@pytest.fixture(scope="module")
+def release_yml(root: Path) -> dict:
+    path = root / ".github" / "workflows" / "release.yml"
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def preinstall_js_src(root: Path) -> str:
+    return (root / "scripts" / "preinstall.js").read_text(encoding="utf-8")
+
+
 # ---------------------------------------------------------------------------
 # Node.js sidecar — package.json & .gitignore
 # ---------------------------------------------------------------------------
@@ -347,6 +363,100 @@ def test_predeploy_typecheck_step_routes_through_pnpm_script(predeploy_yml: dict
         "predeploy.yml still calls `tsc --noEmit` directly — switch to "
         "the typecheck script so tsgo is used"
     )
+
+
+# ---------------------------------------------------------------------------
+# Release publication — package.json, release.yml, preinstall.js
+# ---------------------------------------------------------------------------
+
+
+def _run_steps(job: dict) -> list[dict]:
+    return [step for step in job.get("steps", []) if "run" in step]
+
+
+def test_root_package_uses_public_zeenie_scope(root_pkg: dict):
+    assert root_pkg["name"] == "@zeenie/opencompany"
+    assert root_pkg["publishConfig"] == {
+        "access": "public",
+        "registry": "https://registry.npmjs.org",
+    }
+    assert root_pkg["bin"] == {
+        "company": "./bin/cli.js",
+        "machina": "./bin/machina.js",
+    }
+
+
+def test_root_package_uses_canonical_github_urls(root_pkg: dict):
+    canonical = "https://github.com/zeenie-ai/OpenCompany"
+    assert root_pkg["homepage"] == f"{canonical}#readme"
+    assert root_pkg["repository"] == {
+        "type": "git",
+        "url": f"git+{canonical}.git",
+    }
+    assert root_pkg["bugs"] == {"url": f"{canonical}/issues"}
+
+
+def test_npm_release_authenticates_and_checks_scope_before_publish(
+    release_yml: dict,
+):
+    steps = _run_steps(release_yml["jobs"]["publish-npm"])
+    preflight_index = next(
+        i for i, step in enumerate(steps) if "npm whoami" in step["run"]
+    )
+    publish_index = next(
+        i for i, step in enumerate(steps) if "npm publish" in step["run"]
+    )
+    preflight = steps[preflight_index]
+
+    assert "npm access list packages @zeenie --json" in preflight["run"]
+    assert preflight["env"]["NODE_AUTH_TOKEN"] == "${{ secrets.NPM_TOKEN }}"
+    assert preflight_index < publish_index
+
+
+def test_npm_release_publishes_public_package_with_provenance(release_yml: dict):
+    steps = _run_steps(release_yml["jobs"]["publish-npm"])
+    publish = next(step for step in steps if "npm publish" in step["run"])
+
+    assert publish["run"] == "npm publish --access public --provenance"
+    assert publish["env"]["NODE_AUTH_TOKEN"] == "${{ secrets.NPM_TOKEN }}"
+
+
+def test_github_packages_release_keeps_github_owner_scope(release_yml: dict):
+    steps = _run_steps(release_yml["jobs"]["publish-github-packages"])
+    configure = next(
+        step for step in steps if "pkg.name = '@zeenie-ai/opencompany'" in step["run"]
+    )
+
+    assert "https://npm.pkg.github.com" in configure["run"]
+    assert any(step["run"] == "npm publish" for step in steps)
+
+
+@pytest.mark.parametrize("scope", ["@zeenie", "@zeenie-ai"])
+def test_preinstall_cleans_scoped_npm_temp_directories(
+    preinstall_js_src: str, scope: str
+):
+    assert repr(scope) in preinstall_js_src
+    assert (
+        "cleanupTempDirectories(resolve(nodeModules, scope), scopedTempPrefixes)"
+        in preinstall_js_src
+    )
+    assert "prefixes.some((prefix) => name.startsWith(prefix))" in preinstall_js_src
+
+
+def test_preinstall_does_not_touch_unrelated_unscoped_opencompany_temps(
+    preinstall_js_src: str,
+):
+    assert "const legacyTempPrefixes = ['.machina-']" in preinstall_js_src
+    assert (
+        "cleanupTempDirectories(nodeModules, legacyTempPrefixes)"
+        in preinstall_js_src
+    )
+    assert "cleanupTempDirectories(nodeModules, scopedTempPrefixes)" not in preinstall_js_src
+
+
+def test_preinstall_never_removes_current_package_directory(preinstall_js_src: str):
+    assert "const currentPackageDir = resolve(__dirname, '..')" in preinstall_js_src
+    assert "if (fullPath === currentPackageDir) continue" in preinstall_js_src
 
 
 # ---------------------------------------------------------------------------

--- a/cli/tests/test_release_pipeline_config.py
+++ b/cli/tests/test_release_pipeline_config.py
@@ -427,7 +427,14 @@ def test_github_packages_release_keeps_github_owner_scope(release_yml: dict):
         step for step in steps if "pkg.name = '@zeenie-ai/opencompany'" in step["run"]
     )
 
-    assert "https://npm.pkg.github.com" in configure["run"]
+    registry_assignment = next(
+        line.strip()
+        for line in configure["run"].splitlines()
+        if line.strip().startswith("pkg.publishConfig =")
+    )
+    assert registry_assignment == (
+        "pkg.publishConfig = { registry: 'https://npm.pkg.github.com' };"
+    )
     assert any(step["run"] == "npm publish" for step in steps)
 
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-flow-client",
   "private": true,
-  "version": "0.0.93",
+  "version": "0.0.94",
   "type": "module",
   "scripts": {
     "start": "vite --host 0.0.0.0",

--- a/docs-internal/SCRIPTS.md
+++ b/docs-internal/SCRIPTS.md
@@ -3,7 +3,7 @@
 ## Quick Start
 
 ```bash
-npm install -g opencompany
+npm install -g @zeenie/opencompany
 company start
 ```
 

--- a/docs-internal/SETUP.md
+++ b/docs-internal/SETUP.md
@@ -21,7 +21,7 @@ OpenCompany/
 ## Quick Start
 
 ```bash
-npm install -g opencompany
+npm install -g @zeenie/opencompany
 company start
 ```
 
@@ -32,7 +32,7 @@ Open http://localhost:3000
 **Prerequisites:** Node.js 22+, Python 3.12+, uv, 
 
 ```bash
-git clone https://github.com/zeenie-ai/MachinaOS.git OpenCompany
+git clone https://github.com/zeenie-ai/OpenCompany.git OpenCompany
 cd OpenCompany
 npm run build
 npm run start
@@ -41,7 +41,7 @@ npm run start
 ### Docker
 
 ```bash
-git clone https://github.com/zeenie-ai/MachinaOS.git OpenCompany
+git clone https://github.com/zeenie-ai/OpenCompany.git OpenCompany
 cd OpenCompany
 npm run docker:up
 ```

--- a/docs-internal/ci_cd.md
+++ b/docs-internal/ci_cd.md
@@ -49,7 +49,7 @@ The repo currently ships **exactly 4 workflows** plus one composite action. A nu
 
 | Secret | Used by | Description |
 |--------|---------|-------------|
-| `NPM_TOKEN` | release.yml | npm registry publish (`publish-npm`) |
+| `NPM_TOKEN` | release.yml | npmjs publish access to the public `@zeenie` scope (`publish-npm`) |
 | `GITHUB_TOKEN` | release.yml | GitHub Packages publish (auto-provided) |
 | `MINTLIFY_TOKEN` | docs.yml | Mintlify documentation deployment |
 
@@ -112,20 +112,23 @@ predeploy (uses predeploy.yml)
    |
    +-------------------+
    v                   v
-publish-npm       publish-github-packages
-   |                   |
-   +- build            +- build
-   +- cli version sync +- cli version sync
-   +- npm publish      +- rewrite name -> @zeenie-ai/opencompany
-      --access public  +- npm publish (registry: npm.pkg.github.com)
-      --provenance        NODE_AUTH_TOKEN = GITHUB_TOKEN
-      NODE_AUTH_TOKEN =
-        NPM_TOKEN
+publish-npm                    publish-github-packages
+   |                              |
+   +- build                       +- build
+   +- cli version sync            +- cli version sync
+   +- verify npm auth/scope       +- rewrite package name
+   +- publish canonical package   +- publish mirror package
+      @zeenie/opencompany            @zeenie-ai/opencompany
+      npmjs, public + provenance     npm.pkg.github.com
 ```
 
 - Both publish jobs `needs: predeploy`, run on `ubuntu-latest`, and share the same prefix: `actions/checkout` → composite setup → `actions/setup-node@v4` (with the target `registry-url`) → `pnpm install --frozen-lockfile` → `pnpm run build` → `python -m cli version sync`.
-- `publish-npm` — `npm publish --access public --provenance` with `NODE_AUTH_TOKEN=secrets.NPM_TOKEN`. The `--provenance` flag emits an npm provenance attestation (backed by the workflow's `id-token: write`).
+- `publish-npm` — validates the token with `npm whoami` and `npm access list packages @zeenie --json`, then publishes the canonical public npmjs package `@zeenie/opencompany` via `npm publish --access public --provenance` with `NODE_AUTH_TOKEN=secrets.NPM_TOKEN`. The `--provenance` flag emits an npm provenance attestation (backed by the workflow's `id-token: write`).
 - `publish-github-packages` — rewrites `package.json` `name` to `@zeenie-ai/opencompany` and sets `publishConfig.registry = https://npm.pkg.github.com`, then `npm publish` with `NODE_AUTH_TOKEN=secrets.GITHUB_TOKEN`.
+
+These names intentionally differ by registry: `@zeenie/opencompany` is the
+canonical npmjs package users install, while `@zeenie-ai/opencompany` is the
+GitHub Packages mirror whose scope matches the GitHub organization.
 
 There is currently no audit gate, no PyPI publish, no SLSA `attest-build-provenance` step, and no `create-github-release` / test-install stage — see [Planned](#planned-not-yet-implemented).
 

--- a/docs-internal/design-system/IMPLEMENTATION.md
+++ b/docs-internal/design-system/IMPLEMENTATION.md
@@ -167,4 +167,4 @@ Second person, possessive ("your own AI assistant"). Terse declarative fragments
 - `assets/` — product screenshot + official architecture diagrams (SVG).
 - `readme.md` — design guide (voice, visual foundations, iconography). `SKILL.md` — Agent-Skill entry point.
 
-**Upstream source:** https://github.com/zeenie-ai/MachinaOS (`client/src/index.css`, `client/src/themes/*.css`, `client/src/components/ui/*`). Explore it for any detail this bundle doesn't cover.
+**Upstream source:** https://github.com/zeenie-ai/OpenCompany (`client/src/index.css`, `client/src/themes/*.css`, `client/src/components/ui/*`). Explore it for any detail this bundle doesn't cover.

--- a/docs-internal/design-system/guidelines/THEMES.md
+++ b/docs-internal/design-system/guidelines/THEMES.md
@@ -1,6 +1,6 @@
 # OpenCompany theming architecture — analysis
 
-Source: `client/src/themes/*.css` + `client/src/index.css` in https://github.com/zeenie-ai/MachinaOS (full copies in `reference/themes/`). The app ships **12 themes**: 2 canonical (light, dark) + 10 "skins" (Renaissance, Greek, Edo, Steampunk, Atomic, Cyber, Wasteland, Rot, Plague, Surveillance).
+Source: `client/src/themes/*.css` + `client/src/index.css` in https://github.com/zeenie-ai/OpenCompany (full copies in `reference/themes/`). The app ships **12 themes**: 2 canonical (light, dark) + 10 "skins" (Renaissance, Greek, Edo, Steampunk, Atomic, Cyber, Wasteland, Rot, Plague, Surveillance).
 
 ## 1. How it works — a four-layer contract
 

--- a/docs-internal/design-system/readme.md
+++ b/docs-internal/design-system/readme.md
@@ -3,8 +3,8 @@
 Design system for **OpenCompany** — zeenie.ai's open-source, local-first AI workflow OS. "Your own AI assistant that does real work": users drag, drop, and connect AI agents to email, calendar, messages, phone, and 50+ services on a visual node canvas, then run or deploy workflows that keep running in the background. No code, no subscription; bring your own API keys or run models locally.
 
 **Sources** (explore these to design even better against this product):
-- GitHub: https://github.com/zeenie-ai/MachinaOS — primary source. Key design files: `client/src/index.css` (all color/role tokens), `client/src/themes/{base,light,dark}.css` (contract tokens: surfaces, type, motion), `client/tailwind.config.js`, `client/src/components/ui/` (TopToolbar, ComponentPalette, ActionButton, StatusBar, WorkflowSidebar…), `client/src/components/SquareNode.tsx` (canvas node anatomy), `client/src/assets/icons/index.ts` (icon resolver).
-- Hosted docs: https://docs.zeenie.xyz/ · DeepWiki: https://deepwiki.com/zeenie-ai/MachinaOS
+- GitHub: https://github.com/zeenie-ai/OpenCompany — primary source. Key design files: `client/src/index.css` (all color/role tokens), `client/src/themes/{base,light,dark}.css` (contract tokens: surfaces, type, motion), `client/tailwind.config.js`, `client/src/components/ui/` (TopToolbar, ComponentPalette, ActionButton, StatusBar, WorkflowSidebar…), `client/src/components/SquareNode.tsx` (canvas node anatomy), `client/src/assets/icons/index.ts` (icon resolver).
+- Hosted docs: https://docs.zeenie.xyz/ · DeepWiki: https://deepwiki.com/zeenie-ai/OpenCompany
 - Reference screenshot: `assets/product-canvas-screenshot.png` (real product — dark canvas, neon nodes, WhatsApp automation demo).
 
 ## Product surfaces

--- a/docs-internal/design-system/tokens/colors.css
+++ b/docs-internal/design-system/tokens/colors.css
@@ -1,6 +1,6 @@
 /* ============================================================================
  * OpenCompany — color tokens
- * Source: zeenie-ai/MachinaOS client/src/index.css + client/src/themes/{light,dark}.css
+ * Source: zeenie-ai/OpenCompany client/src/index.css + client/src/themes/{light,dark}.css
  * Light = grey-blue "paper" workspace. Dark = neutral slate dark (the same
  * family inverted, NOT Solarized teal) with Dracula vibrant accents.
  * Toggle dark mode with class="dark" or data-theme="dark" on <html>.

--- a/docs-internal/gcp_vm_deploy_runbook.md
+++ b/docs-internal/gcp_vm_deploy_runbook.md
@@ -1,12 +1,15 @@
 # GCP VM Deploy Runbook (released npm package, manual gcloud + cf)
 
-Step-by-step runbook for deploying the **released** `opencompany` npm package on a fresh
+Step-by-step runbook for deploying the **released** `@zeenie/opencompany` npm package on a fresh
 GCP VM behind a Cloudflare-proxied domain, with the single-owner login gate enabled.
 Written to be executable by an AI agent (or a human) with no other context.
 
 This is the manual path — it does NOT use `company deploy` / Terraform
 (`cli/commands/deploy/`, `cli/terraform/`). It was derived from a real deployment to
-`demo.zeenie.xyz` (June 2026, opencompany@0.0.88) and encodes every pitfall hit on the way.
+`demo.zeenie.xyz` (June 2026, before the scoped-package cutover) and encodes every pitfall hit on the way.
+
+The unscoped `opencompany` package belongs to a different publisher. Do not install
+or remove it while following this runbook.
 
 ## Parameters
 
@@ -46,7 +49,7 @@ print('ENC='+secrets.token_hex(24))"
 ## Known pitfalls (read first — these each cost a redeploy or a debugging loop)
 
 1. **Debian 12 fails.** The npm package's `postinstall` hard-requires Python 3.12+;
-   Debian 12 ships 3.11 and `npm install -g opencompany` exits 1
+   Debian 12 ships 3.11 and `npm install -g @zeenie/opencompany` exits 1
    (`ERROR: Python 3.12+ is required.`). Use **Ubuntu 24.04** (`ubuntu-2404-lts-amd64`
    in `ubuntu-os-cloud`), which ships Python 3.12.
 2. **The released package has no `company serve`.** Released CLI commands are only
@@ -113,7 +116,7 @@ corepack enable || true
 curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 
 echo "[opencompany] installing OpenCompany released package..."
-npm install -g opencompany@latest
+npm install -g @zeenie/opencompany@latest
 
 echo "[opencompany] writing login-gate env..."
 mkdir -p /etc/opencompany
@@ -193,6 +196,8 @@ systemctl reload nginx
 
 echo "[opencompany] installing systemd service (README usage: company start)..."
 OPENCOMPANY_BIN=$(command -v company)
+OPENCOMPANY_PACKAGE_DIR="$(npm root -g)/@zeenie/opencompany"
+test -d "$OPENCOMPANY_PACKAGE_DIR"
 cat > /etc/systemd/system/opencompany.service <<SERVICE_EOF
 [Unit]
 Description=OpenCompany (released, company start)
@@ -202,7 +207,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 EnvironmentFile=/etc/opencompany/opencompany.env
-WorkingDirectory=/usr/lib/node_modules/opencompany
+WorkingDirectory=$OPENCOMPANY_PACKAGE_DIR
 ExecStart=$OPENCOMPANY_BIN start
 Restart=on-failure
 RestartSec=5
@@ -354,7 +359,7 @@ gcloud compute ssh <VM_NAME> --zone=<ZONE> --quiet --command="sudo journalctl -u
 # restart app:
 gcloud compute ssh <VM_NAME> --zone=<ZONE> --quiet --command="sudo systemctl restart opencompany"
 # upgrade to a new release:
-gcloud compute ssh <VM_NAME> --zone=<ZONE> --quiet --command="sudo npm install -g opencompany@latest && sudo systemctl restart opencompany"
+gcloud compute ssh <VM_NAME> --zone=<ZONE> --quiet --command="sudo npm install -g @zeenie/opencompany@latest && sudo systemctl restart opencompany"
 # env (secrets live here):
 #   /etc/opencompany/opencompany.env   (chmod 600; service reads it via EnvironmentFile)
 # data:

--- a/docs-internal/release_build_pipeline.md
+++ b/docs-internal/release_build_pipeline.md
@@ -1,6 +1,6 @@
 # Release Build Pipeline
 
-Compile-step plan for the npm distribution `opencompany`. Goal: cut cold-start ~20s further on top of the lazy-LangChain fix already in v0.0.76, shrink the Vite main bundle below 200 KB gz, and drop the `tsx` interpreter cost from the Node.js sidecar.
+Compile-step plan for the npm distribution `@zeenie/opencompany`. Goal: cut cold-start ~20s further on top of the lazy-LangChain fix already in v0.0.76, shrink the Vite main bundle below 200 KB gz, and drop the `tsx` interpreter cost from the Node.js sidecar.
 
 User scope (confirmed before this work): stay on npm distribution; **no** Nuitka/PyOxidizer standalone binary channel; optimize Vite output too; **skip** the plugin-walker (~11s) and service-status-refresh (~20s) hotspots — those are runtime concerns, not compile-time.
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,5 @@
 # OpenCompany Installer for Windows
-# Usage: iwr -useb https://raw.githubusercontent.com/zeenie-ai/MachinaOS/main/install.ps1 | iex
+# Usage: iwr -useb https://raw.githubusercontent.com/zeenie-ai/OpenCompany/main/install.ps1 | iex
 #
 # This script installs OpenCompany and its dependencies:
 # - Node.js 22+ (via winget/choco)
@@ -159,6 +159,20 @@ function Install-Uv {
     }
 }
 
+# The pre-rebrand package owns the deprecated `machina` command too. Remove it
+# before installing OpenCompany so npm does not fail with an existing shim.
+function Remove-LegacyMachinaOs {
+    npm list -g --depth=0 machinaos *> $null
+    if ($LASTEXITCODE -ne 0) { return }
+
+    Info "Removing legacy machinaos package..."
+    npm uninstall -g machinaos
+    if ($LASTEXITCODE -ne 0) {
+        Error-Exit "Unable to remove legacy machinaos. Run PowerShell as Administrator and retry."
+    }
+    Success "Legacy machinaos package removed"
+}
+
 # =============================================================================
 # Main Installation Flow
 # =============================================================================
@@ -173,12 +187,18 @@ function Main {
     if (-not (Check-Python)) { Install-Python }
     if (-not (Check-Uv)) { Install-Uv }
 
+    # Avoid a collision with the deprecated `machina` compatibility shim.
+    Remove-LegacyMachinaOs
+
     Write-Host ""
     Info "Installing OpenCompany..."
     Write-Host ""
 
     # Install OpenCompany from npm
-    npm install -g opencompany
+    npm install -g "@zeenie/opencompany"
+    if ($LASTEXITCODE -ne 0) {
+        Error-Exit "npm install -g failed. Run PowerShell as Administrator and retry."
+    }
 
     Write-Host ""
     Write-Color "============================================" "Green"

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # OpenCompany Installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/zeenie-ai/MachinaOS/main/install.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/zeenie-ai/OpenCompany/main/install.sh | bash
 #
 # This script installs OpenCompany and its dependencies:
 # - Node.js 22+ (via brew/apt/dnf/pacman)
@@ -99,6 +99,25 @@ setup_wsl_npm() {
     fi
 
     success "npm configured for WSL"
+  fi
+}
+
+# The pre-rebrand package owns the deprecated `machina` binary too. Remove it
+# before installing OpenCompany so npm does not fail with an EEXIST shim clash.
+remove_legacy_machinaos() {
+  if ! npm list -g --depth=0 machinaos &> /dev/null; then
+    return 0
+  fi
+
+  info "Removing legacy machinaos package..."
+  if npm uninstall -g machinaos &> /dev/null; then
+    success "Legacy machinaos package removed"
+  elif command -v sudo &> /dev/null; then
+    info "Retrying legacy package removal with sudo..."
+    sudo npm uninstall -g machinaos
+    success "Legacy machinaos package removed"
+  else
+    error_exit "Unable to remove legacy machinaos. Try: sudo npm uninstall -g machinaos"
   fi
 }
 
@@ -269,19 +288,22 @@ main() {
   # Configure npm for WSL before installing
   setup_wsl_npm
 
+  # Avoid a collision with the deprecated `machina` compatibility shim.
+  remove_legacy_machinaos
+
   echo ""
   info "Installing OpenCompany..."
   echo ""
 
   # Install OpenCompany from npm
   # On Linux/WSL without nvm, global npm install needs sudo unless prefix is user-writable
-  if npm install -g opencompany 2>/dev/null; then
+  if npm install -g '@zeenie/opencompany' 2>/dev/null; then
     : # Installed successfully
   elif command -v sudo &> /dev/null; then
     info "Retrying with sudo..."
-    sudo npm install -g opencompany
+    sudo npm install -g '@zeenie/opencompany'
   else
-    error_exit "npm install -g failed. Try: sudo npm install -g opencompany"
+    error_exit "npm install -g failed. Try: sudo npm install -g @zeenie/opencompany"
   fi
 
   echo ""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zeenie/opencompany",
-  "version": "0.0.93",
+  "version": "0.0.94",
   "description": "Open source workflow automation platform with AI agents, React Flow, and n8n-inspired architecture",
   "type": "module",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opencompany",
+  "name": "@zeenie/opencompany",
   "version": "0.0.93",
   "description": "Open source workflow automation platform with AI agents, React Flow, and n8n-inspired architecture",
   "type": "module",
@@ -17,13 +17,17 @@
   ],
   "author": "Rohit G <trohitg@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/zeenie-ai/MachinaOS#readme",
+  "homepage": "https://github.com/zeenie-ai/OpenCompany#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/zeenie-ai/MachinaOS.git"
+    "url": "git+https://github.com/zeenie-ai/OpenCompany.git"
   },
   "bugs": {
-    "url": "https://github.com/zeenie-ai/MachinaOS/issues"
+    "url": "https://github.com/zeenie-ai/OpenCompany/issues"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
   },
   "bin": {
     "company": "./bin/cli.js",

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -29,7 +29,7 @@ process.env.PYTHONUTF8 = '1';
 
 function run(cmd, cwd = ROOT, timeoutMs = 300000) {
   // Strip VIRTUAL_ENV from the spawned env. When the user runs
-  // ``npm install -g opencompany`` from a shell that has activated a
+  // ``npm install -g @zeenie/opencompany`` from a shell that has activated a
   // venv (very common during dev), uv emits a noisy ``VIRTUAL_ENV
   // ... does not match the project environment path`` warning per
   // invocation. uv only honours VIRTUAL_ENV with ``--active``, which

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -14,6 +14,10 @@ import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const currentPackageDir = resolve(__dirname, '..');
+const legacyTempPrefixes = ['.machina-'];
+const scopedTempPrefixes = ['.opencompany-', '.machina-'];
+const packageScopes = ['@zeenie', '@zeenie-ai'];
 
 // Skip in CI
 if (process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true') {
@@ -52,21 +56,21 @@ function getGlobalNodeModules() {
   return null;
 }
 
-function cleanup() {
-  const nodeModules = getGlobalNodeModules();
-  if (!nodeModules) return;
-
+function cleanupTempDirectories(parentDir, prefixes) {
   try {
-    const entries = readdirSync(nodeModules);
+    const entries = readdirSync(parentDir);
 
-    // Clean current and pre-rebrand npm temp directories.
+    // Clean current and pre-rebrand npm temp directories without deleting the
+    // temporary package directory that is running this preinstall script.
     for (const name of entries) {
-      if (name.startsWith('.opencompany-') || name.startsWith('.machina-')) {
-        const fullPath = resolve(nodeModules, name);
+      if (prefixes.some((prefix) => name.startsWith(prefix))) {
+        const fullPath = resolve(parentDir, name);
+        if (fullPath === currentPackageDir) continue;
+
         try {
           if (statSync(fullPath).isDirectory()) {
             rmSync(fullPath, { recursive: true, force: true });
-            console.log(`Cleaned: ${name}`);
+            console.log(`Cleaned: ${fullPath}`);
           }
         } catch {
           // Ignore
@@ -74,7 +78,23 @@ function cleanup() {
       }
     }
   } catch {
-    // Can't read node_modules - that's fine
+    // Missing or unreadable directory is fine.
+  }
+}
+
+function cleanup() {
+  const nodeModules = getGlobalNodeModules();
+  if (!nodeModules) return;
+
+  // Only the official legacy `machinaos` package owned a top-level package
+  // here. Never remove `.opencompany-*` at this level: the unscoped
+  // `opencompany` package belongs to an unrelated publisher.
+  cleanupTempDirectories(nodeModules, legacyTempPrefixes);
+
+  // Scoped installs place them inside the package scope. Cover the canonical
+  // npmjs scope and the GitHub Packages mirror scope.
+  for (const scope of packageScopes) {
+    cleanupTempDirectories(resolve(nodeModules, scope), scopedTempPrefixes);
   }
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,26 +1,39 @@
 #!/usr/bin/env bash
 # OpenCompany Uninstaller
 #
-# Usage: curl -fsSL https://raw.githubusercontent.com/zeenie-ai/MachinaOS/main/uninstall.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/zeenie-ai/OpenCompany/main/uninstall.sh | bash
 
 set -e
 
 echo "Uninstalling OpenCompany..."
 echo ""
 
-# Uninstall the current package. Also remove the pre-rebrand package when it
-# is still installed so upgrades do not leave two global CLI shims behind.
-if npm list -g opencompany &> /dev/null; then
-  npm uninstall -g opencompany
-  echo "opencompany removed"
-else
-  echo "opencompany not installed"
-fi
+# Remove only OpenCompany's scoped package and the official pre-rebrand
+# package. The unrelated unscoped package named `opencompany` is untouched.
+remove_global_package() {
+  local package_name="$1"
+  local display_name="$2"
 
-if npm list -g machinaos &> /dev/null; then
-  npm uninstall -g machinaos
-  echo "legacy machinaos package removed"
-fi
+  if ! npm list -g --depth=0 "$package_name" &> /dev/null; then
+    echo "$display_name not installed"
+    return 0
+  fi
+
+  if npm uninstall -g "$package_name" &> /dev/null; then
+    :
+  elif command -v sudo &> /dev/null; then
+    echo "Retrying $display_name removal with sudo..."
+    sudo npm uninstall -g "$package_name"
+  else
+    echo "Unable to remove $display_name. Try: sudo npm uninstall -g $package_name" >&2
+    exit 1
+  fi
+
+  echo "$display_name removed"
+}
+
+remove_global_package '@zeenie/opencompany' '@zeenie/opencompany'
+remove_global_package 'machinaos' 'legacy machinaos package'
 
 echo ""
 echo "Done!"


### PR DESCRIPTION
Publishes OpenCompany to npmjs as @zeenie/opencompany, keeps the GitHub Packages mirror at @zeenie-ai/opencompany, updates installers and documentation, adds release safety tests, and bumps the release to 0.0.94. Validation completed locally: production build, lint, typecheck, 162 frontend tests, 129 CLI tests, 1766 backend tests, and isolated tarball installation.