### PR TITLE
perf: fix the boot-delay regressions (71s cold / 2m40s dev boot -> 21.5s / seconds)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@ This is a React Flow-based workflow automation platform implementing n8n-inspire
 | **[Vercel Service](./docs-internal/vercel_service.md)** | Vercel CLI integration — `vercelAction` (deploy / inspect / list + `custom` CLI passthrough; AI tool `vercel`). Second reference for the CLI-managed-auth pattern: the **device-flow variant** (`vercel login` is one blocking process — no two-step `--complete`; direct `create_subprocess_exec` + chunk-based banner read for the code-embedding URL, pumps drain pipes for the process lifetime, success gate = auth.json mtime advance + sniff). Dual auth: optional `vercel_token` field (injected as `VERCEL_TOKEN` env, never argv) OR CLI login with marker tokens. All invocations pin `--global-config <DATA_DIR>/vercel/` (the `CLAUDE_CONFIG_DIR` isolation idiom). npm install into the shared packages tree (pinned version). First-deploy project guard raises `NodeUserError` instead of letting Vercel derive an invalid name from the workspace dir. Shipped with the generic OAuthConnect change: Login gates on **required** fields only, so optional fields never block CLI login. |
 | **[GitHub Service](./docs-internal/github_service.md)** | GitHub CLI integration — `githubAction` (repo_clone / pr_create / pr_list / pr_merge / issue_create / issue_list + `custom` passthrough; AI tool `github`). **Strict Stripe pattern: the gh CLI owns its own auth** — no token stored/injected by OpenCompany, no auth pre-flight (gh's own error surfaces), marker OAuth row for the modal badge, fieldless catalogue entry. Login = spawned `gh auth login --hostname github.com --git-protocol https --web` — source-verified: headless takes the `isInteractive=false` branch (no Press-Enter), prints one-time code + `github.com/login/device` URL on stderr; the modal shows the code via the generic `verificationCode` plumbing (`useCredentialPanel` → `OAuthConnect`). `login_env()` strips `GH_TOKEN`/`GITHUB_TOKEN` (login aborts otherwise). Success gate = `gh auth status` exit 0, then best-effort **`gh auth setup-git`** (official bridge — the future git node needs zero auth code). gh binary: **project-local, pooch-driven** (temporal `_install.py` idiom) — pinned release under `package_dir("gh")`, system gh never consulted (auth state still shared: gh config paths are user-level). Palette group `vcs`. |
 | **[CI/CD Pipeline](./docs-internal/ci_cd.md)** | GitHub Actions workflows, predeploy validation, release publishing, and composite setup action |
-| **[Performance](./docs-internal/performance.md)** | Cold-start measurements (Application startup complete 2.90 s warm, first WS connect 8.29 s) + per-phase timeline + optimisation history (lazy LangChain imports, esbuild sidecar bundle, scoped `compileall`, PartySocket reconnect, TanStack Query auth bootstrap, `manualChunks`) + bottleneck inventory + reproduction commands + anti-patterns to never reintroduce. Pairs with the build-time pipeline doc below. |
-| **[Release Build Pipeline](./docs-internal/release_build_pipeline.md)** | npm-distribution build pipeline: `tsgo` for type-check (5× faster than tsc), Vite `manualChunks` + `target: 'es2022'`, esbuild Node.js sidecar bundle (drops `tsx` interpreter cost), `python -O -m compileall` for project-source bytecode (excludes `.venv/`, `tests/`). Single source of truth for the bytecode-compile path list: `cli.commands.build.COMPILEALL_SOURCE_DIRS`. |
+| **[Performance](./docs-internal/performance.md)** | Cold-start measurements (Application startup complete 2.90 s warm, 21.5 s cold post-`company clean` — was 71 s before the 2026-07-14 boot-delay fixes; first WS connect 8.29 s) + warm and cold per-phase timelines + optimisation history (lazy LangChain imports, lazy LLM-SDK exception refs, esbuild sidecar bundle, bytecode-at-build, PartySocket reconnect, TanStack Query auth bootstrap, `manualChunks`, Vite dep-cache preservation, off-loop Temporal build-id hash) + bottleneck inventory + reproduction commands + anti-patterns to never reintroduce (incl. eager SDK import at LLM provider registration, unconditional `.vite` wipe, synchronous `Worker()` on the event loop). Pairs with the build-time pipeline doc below. |
+| **[Release Build Pipeline](./docs-internal/release_build_pipeline.md)** | npm-distribution build pipeline: `tsgo` for type-check (5× faster than tsc), Vite `manualChunks` + `target: 'es2022'`, esbuild Node.js sidecar bundle (drops `tsx` interpreter cost), bytecode pre-compile in two halves — `[tool.uv] compile-bytecode = true` (uv sync compiles `.venv/` site-packages) + `python -m compileall` for project source (plain `.pyc`, **no `-O`** — per PEP 488 the non-`-O` runtimes never load `.opt-1.pyc`; excludes `.venv/`, `tests/`). Single source of truth for the bytecode-compile path list: `cli.commands.build.COMPILEALL_SOURCE_DIRS`. |
 | **[Workflow Schema](./docs-internal/workflow-schema.md)** | JSON schema for workflows, edge handle conventions, config node architecture |
 | **[Execution Engine Design](./docs-internal/DESIGN.md)** | Architecture patterns, design standards, and implementation details for the workflow execution engine |
 | **[Execution Roadmap](./docs-internal/ROADMAP.md)** | Implementation status, completed phases, and pending features |
@@ -138,13 +138,16 @@ server/services/
 │   ├── triggers.py          # Generic event-trigger handler
 │   ├── todo.py              # writeTodos execution shim (used by every agent)
 │   └── __init__.py          # Docstring only (google_auth.py retired into nodes/google/_auth_helper.py)
-├── llm/                     # Native LLM provider SDKs (replaces LangChain for chat)
+├── llm/                     # Native LLM provider SDKs (chat path; the agent loop in ai.py is still LangChain)
 │   ├── __init__.py          # Public API exports
 │   ├── protocol.py          # ThinkingConfig, Message, LLMResponse, LLMProvider Protocol
 │   ├── config.py            # ProviderConfig, resolve_max_tokens, resolve_temperature
 │   ├── factory.py           # create_provider() lazy-import factory
+│   ├── registry.py          # ProviderSpec + register_provider — sdk_exception_refs are LAZY "module:Class" strings resolved via pkgutil.resolve_name at except/read time; NEVER import an SDK at registration (locked by tests/llm/test_lazy_sdk_imports.py)
+│   ├── unifier.py           # ChatUnifier facade — routes chat/fetch_models, translates typed SDK errors → NodeUserError, applies incompatible_models filter
+│   ├── vertex.py            # Vertex / Agent-Platform key handling
 │   ├── messages.py          # filter_empty_messages, is_valid_message_content
-│   └── providers/           # Per-provider implementations
+│   └── providers/           # Per-provider implementations (+ _compat.py for the 8 OpenAI-compatible providers)
 │       ├── anthropic.py     # AnthropicProvider (anthropic SDK)
 │       ├── openai.py        # OpenAIProvider (openai SDK)
 │       ├── gemini.py        # GeminiProvider (google-genai SDK)
@@ -690,12 +693,13 @@ Workflows execute via Temporal for durability and horizontal scaling, gated by `
 
 ### CLI Commands (after the global install)
 ```bash
-company start      # Start all services
-company stop       # Stop all services
-company build      # Build for production
-company clean      # Clean build artifacts
-company docker:up  # Start with Docker
-company help       # Show all commands
+company start        # Start all services (production mode)
+company dev          # Start all services in dev mode (Vite HMR)
+company dev --force  # ...forcing Vite to re-bundle deps (recovers "Outdated Optimize Dep"; sets VITE_FORCE -> optimizeDeps.force — the dep cache is otherwise preserved across boots)
+company stop         # Stop all services
+company build        # Build for production
+company clean        # Clean build artifacts
+company help         # Show all commands
 ```
 
 ### npm Scripts

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -62,10 +62,15 @@ def _dev(
         "--daemon",
         help="Bind backend to 0.0.0.0 instead of 127.0.0.1.",
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Force Vite to re-bundle dependencies (recovers 'Outdated Optimize Dep' errors).",
+    ),
 ) -> None:
     from cli.commands.dev import dev_command
 
-    dev_command(daemon=daemon)
+    dev_command(daemon=daemon, force=force)
 
 
 @app.command(

--- a/cli/commands/build.py
+++ b/cli/commands/build.py
@@ -33,12 +33,13 @@ from cli.platform_ import node_modules_dir, project_root, server_dir
 
 
 # Source dirs / entry-point modules under ``server/`` that ``company build``
-# pre-compiles to optimised bytecode in step [5/6]. Public so tests and
+# pre-compiles to plain .pyc bytecode in step [5/6]. Public so tests and
 # ``scripts/install.js`` (which mirrors this list) stay in sync — both
 # the install pipeline and tests should read this constant rather than
-# duplicate the list. Excludes ``.venv/`` (uv compiles deps at install
-# time and some site-packages contain non-Python templates) and
-# ``tests/`` (ships outside the production tarball).
+# duplicate the list. Excludes ``.venv/`` (compiled by ``uv sync`` via
+# ``[tool.uv] compile-bytecode = true`` in server/pyproject.toml; some
+# site-packages also contain non-Python templates) and ``tests/``
+# (ships outside the production tarball).
 COMPILEALL_SOURCE_DIRS: tuple[str, ...] = (
     "services",
     "core",
@@ -201,20 +202,24 @@ def build_command() -> None:
     # is idempotent and creates the venv on first run.
     run(["uv", "sync"], cwd=server_cwd)
 
-    # Pre-compile our Python sources to optimised bytecode (.opt-1.pyc).
-    # `-O` strips `assert` statements + `__debug__` branches; `-q`
-    # silences per-file output (errors still print); `-j 0` parallelises
-    # across all CPU cores. Cuts a measurable few seconds off cold
-    # start by avoiding source-to-bytecode work on first import.
+    # Pre-compile our Python sources to plain .pyc. No `-O`: every
+    # runtime (uvicorn via `uv run`, `company serve`'s venv python) runs
+    # WITHOUT -O, and per PEP 488 a non-optimized interpreter only loads
+    # plain .pyc — `-O`-produced .opt-1.pyc files are never loaded and
+    # the sources get recompiled on first import anyway. `-q` silences
+    # per-file output (errors still print); `-j 0` parallelises across
+    # all CPU cores.
     #
-    # Scoped to the project's own source dirs — `uv sync` already
-    # compiles `.venv/` packages, and `tests/` ships outside the
-    # tarball. Compiling `.venv/` is wasted work and fails on cookiecutter
-    # template files inside packages like crawlee that aren't real Python.
+    # Scoped to the project's own source dirs — `.venv/` packages are
+    # compiled by `uv sync` itself via `[tool.uv] compile-bytecode = true`
+    # in server/pyproject.toml, and `tests/` ships outside the tarball.
+    # Compiling `.venv/` here would be duplicate work and fails on
+    # cookiecutter template files inside packages like crawlee that
+    # aren't real Python.
     console.log("[5/6] Compiling Python bytecode...")
     run(
         uv_run(
-            "python", "-O", "-m", "compileall", "-q", "-j", "0", *COMPILEALL_SOURCE_DIRS
+            "python", "-m", "compileall", "-q", "-j", "0", *COMPILEALL_SOURCE_DIRS
         ),
         cwd=server_cwd,
         check=False,  # missing pyc is non-fatal — runtime regenerates as needed

--- a/cli/commands/dev.py
+++ b/cli/commands/dev.py
@@ -1,8 +1,18 @@
 """``company dev`` -- replaces ``scripts/dev.js``.
 
-Development launcher: validates the build, frees ports, clears the
-Vite dep cache (fixes "Outdated Optimize Dep" errors), then spawns
+Development launcher: validates the build, frees ports, then spawns
 Vite + uvicorn + temporal-server under ``Manager.run()``.
+
+The Vite dep cache (``client/node_modules/.vite``) is preserved across
+boots -- Vite self-invalidates it via the lockfile/config hashes in
+``.vite/deps/_metadata.json``, and an unconditional wipe forced a full
+esbuild re-optimize (minutes on Windows) on every first page load.
+``--force`` maps to Vite's own force-re-bundle mechanism
+(``optimizeDeps.force`` via the ``VITE_FORCE`` env var, read in
+``client/vite.config.js``) -- the documented recovery for an
+"Outdated Optimize Dep" error. Env var rather than argv because the
+client spec runs ``pnpm run client:start`` -> ``npm run start`` and a
+``--force`` suffix does not survive the double ``npm run`` indirection.
 
 uvicorn ``--reload``-style restarts (exit code 1) used to cascade-kill
 the frontend under ``concurrently --kill-others``. Our supervisor
@@ -14,7 +24,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import shutil
 from pathlib import Path
 
 import typer
@@ -38,18 +47,9 @@ def _has_vite(root: Path) -> bool:
     ).exists()
 
 
-def _clear_vite_cache(root: Path) -> None:
-    cache = root / "client" / "node_modules" / ".vite"
-    if not cache.exists():
-        return
-    try:
-        shutil.rmtree(cache)
-        console.print("Cleared Vite cache")
-    except OSError as exc:
-        console.print(f"[yellow]Warning: Could not clear Vite cache: {exc}[/]")
-
-
-def _build_specs(root: Path, cfg, *, daemon: bool, use_vite: bool) -> list[ServiceSpec]:
+def _build_specs(
+    root: Path, cfg, *, daemon: bool, use_vite: bool, force: bool = False
+) -> list[ServiceSpec]:
     if use_vite:
         client_spec = ServiceSpec(
             name="client",
@@ -57,6 +57,7 @@ def _build_specs(root: Path, cfg, *, daemon: bool, use_vite: bool) -> list[Servi
             cwd=root,
             ready_port=cfg.client_port,
             ready_timeout=60.0,
+            env={"VITE_FORCE": "1"} if force else {},
         )
     else:
         client_spec = ServiceSpec(
@@ -76,6 +77,11 @@ def dev_command(
         False,
         "--daemon",
         help="Bind backend to 0.0.0.0 instead of 127.0.0.1.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Force Vite to re-bundle dependencies (recovers 'Outdated Optimize Dep' errors).",
     ),
 ) -> None:
     # Layer ``.env.dev`` (committed) on top of ``.env.template`` + ``.env``
@@ -101,14 +107,16 @@ def dev_command(
     free_all_ports(cfg)
     console.log("Ports ready")
 
-    _clear_vite_cache(root)
-
     use_vite = _has_vite(root)
     console.print(f"Client:   {'Vite dev server' if use_vite else 'Static server'}")
+    if force:
+        console.print("Vite:     forced dependency re-bundle (--force)")
     console.print()
 
     manager = Manager()
-    manager.add_all(_build_specs(root, cfg, daemon=daemon, use_vite=use_vite))
+    manager.add_all(
+        _build_specs(root, cfg, daemon=daemon, use_vite=use_vite, force=force)
+    )
     rc = asyncio.run(manager.run())
     if rc != 0:
         raise typer.Exit(code=rc)

--- a/cli/tests/test_build_compile_pipeline.py
+++ b/cli/tests/test_build_compile_pipeline.py
@@ -3,7 +3,7 @@
 Covers the two new steps wired into ``cli.commands.build.build_command``:
 
 - ``[3/6] Building Node.js sidecar`` -> ``pnpm --filter opencompany-nodejs-executor run build``
-- ``[5/6] Compiling Python bytecode`` -> ``uv run python -O -m compileall -q -j 0 ...``
+- ``[5/6] Compiling Python bytecode`` -> ``uv run python -m compileall -q -j 0 ...``
 
 The orchestrator is exercised once per test with every external surface
 mocked (toolchain probes, ``run``, ``project_root``) so the assertions
@@ -163,9 +163,12 @@ def test_only_one_sidecar_bundle_invocation(tmp_path: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_compileall_uses_optimised_flag_quiet_and_parallel(tmp_path: Path):
-    """``-O`` strips asserts; ``-q`` silences per-file output; ``-j 0``
-    parallelises across all CPU cores.
+def test_compileall_emits_plain_pyc_quiet_and_parallel(tmp_path: Path):
+    """No ``-O``: every runtime launches python without ``-O`` and per
+    PEP 488 a non-optimized interpreter only loads plain ``.pyc`` —
+    ``.opt-1.pyc`` from ``-O`` would never be loaded and sources would
+    recompile on first import anyway. ``-q`` silences per-file output;
+    ``-j 0`` parallelises across all CPU cores.
     """
     captured = _run_build_capture_invocations(tmp_path)
     match = _find_call(captured, lambda c: "compileall" in c)
@@ -173,7 +176,10 @@ def test_compileall_uses_optimised_flag_quiet_and_parallel(tmp_path: Path):
         match is not None
     ), f"compileall step missing in {[c['argv'] for c in captured]}"
     argv = match[1]["argv"]
-    assert "-O" in argv, "must use -O for .opt-1.pyc output"
+    assert "-O" not in argv, (
+        "-O emits .opt-1.pyc that the non-optimized runtime never loads "
+        "(PEP 488) — compile plain .pyc instead"
+    )
     assert "-q" in argv, "must use -q to silence per-file logging"
     assert "-j" in argv, "must enable parallelism via -j"
     j_idx = argv.index("-j")
@@ -195,9 +201,9 @@ def test_compileall_runs_via_uv_run_python(tmp_path: Path):
         "run",
         "--no-sync",
         "python",
-        "-O",
         "-m",
-    ], f"expected `uv run --no-sync python -O -m compileall ...`, got {argv[:7]}"
+        "compileall",
+    ], f"expected `uv run --no-sync python -m compileall ...`, got {argv[:7]}"
 
 
 def test_compileall_path_list_matches_source_dirs_constant(tmp_path: Path):
@@ -349,7 +355,7 @@ def test_pipeline_order_client_then_sidecar_then_uv_then_compileall(tmp_path: Pa
     1. client build  (``pnpm --filter react-flow-client run build``)
     2. sidecar bundle (``pnpm --filter opencompany-nodejs-executor run build``)
     3. uv sync       (``uv sync``)
-    4. compileall    (``uv run python -O -m compileall ...``)
+    4. compileall    (``uv run python -m compileall ...``)
 
     compileall MUST follow uv sync because it invokes ``uv run python``,
     which requires the venv to exist.

--- a/cli/tests/test_dev.py
+++ b/cli/tests/test_dev.py
@@ -30,17 +30,30 @@ def test_has_vite_true_when_in_client_node_modules(tmp_path: Path):
     assert dev._has_vite(tmp_path) is True
 
 
-def test_clear_vite_cache_no_op_when_missing(tmp_path: Path):
-    # Just shouldn't raise.
-    dev._clear_vite_cache(tmp_path)
+def test_dev_command_force_flag_defaults_false():
+    # The Vite dep cache must survive normal boots -- an unconditional
+    # wipe forced a full esbuild re-optimize (minutes on Windows) on
+    # every first page load. ``--force`` is the explicit opt-in and maps
+    # to Vite's own ``optimizeDeps.force`` via the VITE_FORCE env var.
+    import inspect
+
+    params = inspect.signature(dev.dev_command).parameters
+    assert "force" in params
+    assert params["force"].default.default is False  # typer.Option wrapper
 
 
-def test_clear_vite_cache_removes_present(tmp_path: Path):
-    cache = tmp_path / "client" / "node_modules" / ".vite"
-    cache.mkdir(parents=True)
-    (cache / "deps.json").write_text("{}")
-    dev._clear_vite_cache(tmp_path)
-    assert not cache.exists()
+def test_build_specs_force_sets_vite_force_env(tmp_path: Path):
+    cfg = _cfg()
+    specs = dev._build_specs(tmp_path, cfg, daemon=False, use_vite=True, force=True)
+    client = next(s for s in specs if s.name == "client")
+    assert client.env.get("VITE_FORCE") == "1"
+
+
+def test_build_specs_default_does_not_set_vite_force_env(tmp_path: Path):
+    cfg = _cfg()
+    specs = dev._build_specs(tmp_path, cfg, daemon=False, use_vite=True)
+    client = next(s for s in specs if s.name == "client")
+    assert "VITE_FORCE" not in client.env
 
 
 def test_build_specs_dev_uses_vite_when_available(tmp_path: Path):

--- a/cli/tests/test_release_pipeline_config.py
+++ b/cli/tests/test_release_pipeline_config.py
@@ -472,21 +472,42 @@ def test_preinstall_never_removes_current_package_directory(preinstall_js_src: s
 
 # Single source of truth for parsing install.js's compileall command line.
 # Must match the shape that build.py emits exactly:
-#     uv run python -O -m compileall -q -j 0 <dirs...>
+#     uv run python -m compileall -q -j 0 <dirs...>
+# No -O: runtimes launch python without -O and per PEP 488 only load
+# plain .pyc — .opt-1.pyc output would never be used.
 _INSTALL_JS_COMPILEALL_RE = re.compile(
-    r"""['"]uv\s+run\s+python\s+-O\s+-m\s+compileall\s+-q\s+-j\s+0\s+([^'"]+)['"]"""
+    r"""['"]uv\s+run\s+python\s+-m\s+compileall\s+-q\s+-j\s+0\s+([^'"]+)['"]"""
 )
 
 
 def test_install_js_compileall_command_shape(install_js_src: str):
     """End-user ``npm install opencompany`` runs install.js. The
     compileall step must use the same shape as ``company build`` —
-    ``uv run python -O -m compileall -q -j 0`` — so cold-start gains
-    apply to the npm-tarball path too.
+    ``uv run python -m compileall -q -j 0`` (plain .pyc, no -O) — so
+    cold-start gains apply to the npm-tarball path too.
     """
     assert (
         _INSTALL_JS_COMPILEALL_RE.search(install_js_src) is not None
-    ), "install.js must run `uv run python -O -m compileall -q -j 0 ...`"
+    ), "install.js must run `uv run python -m compileall -q -j 0 ...`"
+
+
+def test_server_pyproject_enables_uv_compile_bytecode(root: Path):
+    """``[tool.uv] compile-bytecode = true`` must stay set in
+    server/pyproject.toml — uv's default is false, which leaves all
+    site-package ``.py`` files to compile lazily on the FIRST import
+    after a fresh ``uv sync`` (tens of seconds on a post-clean cold
+    boot). The compileall step above only covers project source; this
+    setting covers ``.venv/``.
+    """
+    import tomllib
+
+    pyproject = tomllib.loads(
+        (root / "server" / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    assert pyproject.get("tool", {}).get("uv", {}).get("compile-bytecode") is True, (
+        "server/pyproject.toml must set [tool.uv] compile-bytecode = true "
+        "(cold-boot bytecode precompilation for site-packages)"
+    )
 
 
 def test_install_js_compileall_paths_match_source_dirs_constant(install_js_src: str):

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -93,6 +93,26 @@ export default defineConfig(({ mode }) => {
       strictPort: false,
       host: true
     },
+    optimizeDeps: {
+      // `company dev --force` sets VITE_FORCE to re-run dependency
+      // pre-bundling — Vite's own recovery for "Outdated Optimize Dep"
+      // (equivalent to `vite --force`, which can't be threaded through
+      // the pnpm run -> npm run indirection as an argv flag).
+      force: !!getEnv('VITE_FORCE', ''),
+      // Pre-bundle the heavy deps reached through lazily-loaded panels
+      // (chat/markdown stack, canvas) so a late discovery can't trigger
+      // a mid-session re-optimization — the root cause of the
+      // "Outdated Optimize Dep" 504 (vitejs/vite#14284).
+      include: [
+        'reactflow',
+        'react-markdown',
+        'remark-gfm',
+        'remark-breaks',
+        'prismjs',
+        'react-simple-code-editor',
+        '@uiw/react-json-view',
+      ],
+    },
     build: {
       // ES2022 unlocks native `findLast`, optional-chaining-assignment,
       // class-fields without polyfills. Browser baseline: Chrome 94+,

--- a/docs-internal/litellm_router_migration_rfc.md
+++ b/docs-internal/litellm_router_migration_rfc.md
@@ -332,7 +332,9 @@ credential lookup — plus ~420 LOC of contract tests that pass unchanged if it 
   NodeUserError-on-unknown-provider). Under the flag, registration becomes one
   data-driven loop over `LLM_DEFAULTS["providers"]` registering
   `ProviderSpec(name=n, factory=partial(LiteLLMAdapter, provider=n),
-  sdk_exception_types=(openai.OpenAIError,), client_kwargs={})`.
+  sdk_exception_refs=("openai:OpenAIError",), client_kwargs={})`.
+  (Since 2026-07-14 the spec takes lazy `"module:Class"` refs — the
+  resolved-classes surface remains the `sdk_exception_types` property.)
 - **`unifier.py` changes ~15 lines**: a flag branch in `_build_client`
   (unifier.py:114) plus `fetch_models` delegation to the retained HTTP lister
   (section 6.7). Public signatures unchanged — `test_wiring.py`,
@@ -442,8 +444,10 @@ def _litellm():
 ```
 
 Nothing at `services.llm` import time may touch litellm — `core/container.py` imports
-`services.llm` during container boot. `sdk_exception_types=(openai.OpenAIError,)`
-deliberately avoids importing litellm at registration. New guard test
+`services.llm` during container boot. `sdk_exception_refs=("openai:OpenAIError",)`
+deliberately avoids importing litellm (or any SDK) at registration — the same lazy-ref
+contract `tests/llm/test_lazy_sdk_imports.py` already enforces for openai/anthropic/
+google-genai. New guard test
 `tests/llm/test_lazy_litellm.py`: import `services.llm`, construct `ChatUnifier`, assert
 `"litellm" not in sys.modules`. Phase 0 asserts the three module-setting attribute names
 on the pinned version so a rename fails in CI, not production.

--- a/docs-internal/performance.md
+++ b/docs-internal/performance.md
@@ -18,13 +18,21 @@ warm OS file cache, with bytecode pre-compile applied:
 | First WebSocket client connected | **8.29 s** | same |
 | Status broadcasters fully settled | **12.27 s** | same |
 | AIService import (warm) | **703 ms** | same — was ~31 s on v0.0.75 |
+| Application startup complete (cold, post-`company clean` first launch) | **21.5 s** | `cold.txt` 18:44 (2026-07-14, post boot-delay fixes; was **71 s** the same day pre-fix) |
+| LLM provider registration (all 12, cold) | **17 ms** | same — was 44.6 s pre-fix (eager SDK imports) |
 | Vite production build | **~16 s** | last `vite build` run |
 | Vite main bundle | **234 KB gz** | `client/dist/assets/index-*.js` |
 
-The cold-disk first launch on the same code is ~2× slower because the
-Python interpreter regenerates `.pyc` files on the fly. Run
-`company build` once to pre-compile (see ["Pre-compile Python bytecode"]
-below) and subsequent launches hit the warm number.
+The cold-disk first launch on the same code is slower because Windows
+Defender first-touch-scans freshly written files (the rebuilt `.venv`
+is ~389 MB / 18,300 files) and fresh DBs/salt are created. Before the
+2026-07-14 boot-delay fixes a post-`company clean` boot measured
+**71 s** (5.2× the warm boot / 24× the baseline; `cold.txt` 12:55);
+after the fixes the same cycle measures **21.5 s** (`cold.txt` 18:44).
+The remaining cold gap over the 2.90 s warm number is Defender/disk
+I/O plus the items in "Open follow-ups" — not bytecode compilation,
+which now happens at build time (`[tool.uv] compile-bytecode = true`
++ the `-O`-less compileall step below).
 
 ## Optimisation history
 
@@ -40,6 +48,7 @@ corresponding `start.log` measurement.
 | 2026-05-05 | Scoped `python -O -m compileall` over project source dirs (excludes `.venv/`, `tests/`) | 3-5 s on warm-disk imports | `0b45fb1` | same |
 | 2026-05-05 | Test coverage: 12 build-orchestrator + 32 config-contract tests under `cli/tests/` | n/a (regression guard) | `0f1e55e` | same |
 | 2026-05-06 | Frontend WS reconnect → PartySocket; auth bootstrap → TanStack Query; CloudEvents envelope typed | **~20 s** (eliminates +12 s WS drop + +7 s reconnect cycle on cold start) | `e77215c` | inline plan |
+| 2026-07-14 | Boot-delay fix set: (1) lazy `"module:Class"` SDK exception refs on `ProviderSpec` (no SDK import at provider registration); (2) `[tool.uv] compile-bytecode = true` + `-O`-less compileall (bytecode compiled at build for the interpreter that actually runs); (3) Vite dep cache preserved across `company dev` boots (`--force` → `VITE_FORCE` → `optimizeDeps.force`) + `optimizeDeps.include` for heavy lazily-reached deps; (4) temporalio build-id hash pre-warmed off-loop via `asyncio.to_thread` | **~50 s** on post-clean cold boot (71 s → 21.5 s); ~7 s on warm boot (AIService import back to baseline); ~2 min of Vite re-optimize per warm dev boot; event loop no longer frozen ~3 s during Temporal worker start | this change | plan file `analyze-the-log-txt-file-eager-locket.md`; log evidence `log.txt` / `cold.txt` (2026-07-14) |
 
 ## Where launch time is spent today (post `e77215c`, warm cache)
 
@@ -68,6 +77,31 @@ T+8.29 — First WebSocket client connected ◀ UI-interactive point
        ├── Telegram bot validated + polling started
        └── WhatsApp RPC connected (10.93 s)
 T+12.27 — Status broadcasters settled ◀ "everything green"
+```
+
+## Cold post-clean boot (2026-07-14, `cold.txt` 18:44, post-fix)
+
+First launch after `company clean` → `company build` (fresh `.venv`,
+fresh DATA_DIR: new salt + example import). Segment deltas vs the
+same-day pre-fix cold boot in parentheses:
+
+```
+T+0.00 — port-free begin
+T+2.6  — container: core imports done          (was 10.2 s → 1.2 s segment)
+T+3.2  — AIService imported, 12 providers in 17 ms  (was 44.6 s segment)
+T+8.7  — 152 node plugins loaded               (was 10.8 s → 4.7 s segment)
+T+11.9 — Lifespan startup begin                (3.2 s gap: CLI-agent MCP mount)
+T+21.5 — Application startup complete          (lifespan 9.6 s: fresh-DB init 4.4 s,
+                                                salt/PBKDF2 + encryption ~3 s — see follow-ups)
+T+22.2 — ready on port 3010                    (pre-fix: probe timed out at 30 s,
+                                                line never printed)
+T+27    — Temporal worker registered; worker_start span 7.6 s wall but OFF-LOOP:
+          broadcaster refreshes + WhatsApp RPC handshake interleave mid-hash
+          (pre-fix: 3.1 s synchronous loop freeze)
+T+44    — browser connects once, full init burst answered in <0.6 s
+          (pre-fix: insta-disconnect + reload churn + 8 s starved gap;
+           ~40 s here is post-clean one-time Vite dep optimize + human open)
+T+51    — example workflows imported (still inline — see follow-ups)
 ```
 
 ## The remaining +5 s gap (HTTP-ready → first WS connect)
@@ -110,7 +144,7 @@ optimisations above; sum is what hurts.
 
 | # | Bottleneck | Cost | Class | Notes |
 |---|---|---|---|---|
-| 1 | Plugin walker on lifespan (137 modules under `server/nodes/`) | ~0.8 s | Backend | Out-of-scope per user direction; `_HANDLER_REGISTRY` populates via `BaseNode.__init_subclass__`. Lazy-load would shave another ~0.5 s. |
+| 1 | Plugin walker at import time (152 modules under `server/nodes/`; ~2 s warm / ~4.7 s cold, dominated by `nodes/google`'s eager `googleapiclient` import) | ~2 s | Backend | `_HANDLER_REGISTRY` populates via `BaseNode.__init_subclass__` at import. Lazy `googleapiclient` is the cheap win (see follow-ups); full lazy-loading of the walker is the big-blast-radius option. |
 | 2 | TanStack Query auth bootstrap retry window | ~3-5 s | Frontend | See "remaining +5 s gap" above. |
 | 3 | LangChain ecosystem imports inside `services/ai.py` | ~0.7 s | Backend | Already lazied; further wins require refactoring `AgentState`'s `Annotated[Sequence[BaseMessage], ...]` to defer `BaseMessage` resolution. |
 | 4 | Status-broadcaster refresh (`refresh_all_services`, 2.6 s) | ~2.6 s | Backend | Runs after `Application startup complete`, doesn't block server-ready. WhatsApp + Telegram are the long tails. |
@@ -118,25 +152,38 @@ optimisations above; sum is what hurts.
 
 ## Pre-compile Python bytecode
 
-The build-pipeline step that produces `.opt-1.pyc` files for the
-project's own modules (excludes `.venv/`, `tests/`):
+Two halves, both required — measured on a post-`company clean` cold
+boot (2026-07-14, `cold.txt`): without them the boot hit **71 s** to
+"Application startup complete" (5.2× the warm boot, 24× the 2.90 s
+baseline), not the "~2×" this doc previously claimed.
+
+**1. Site-packages** — `server/pyproject.toml` sets
+`[tool.uv] compile-bytecode = true` so `uv sync` compiles the ~9,700
+dependency `.py` files at install time. uv's default is **false**;
+without it every dependency compiles lazily on the FIRST import after
+a fresh sync — tens of seconds on Windows where Defender also
+first-touch-scans each newly written file.
+
+**2. Project source** — the build-pipeline step (excludes `.venv/`,
+`tests/`):
 
 ```bash
 cd server
-uv run python -O -m compileall -q -j 0 services core nodes routers models middleware main.py constants.py
+uv run python -m compileall -q -j 0 services core nodes routers models middleware main.py constants.py
 ```
+
+No `-O`: every runtime launches python without `-O`, and per PEP 488 a
+non-optimized interpreter only loads plain `.pyc` — the previous `-O`
+invocation produced `.opt-1.pyc` files that nothing ever loaded.
 
 `company build` runs this as step `[5/6]`. The path list lives in
 [cli/commands/build.py](../cli/commands/build.py)'s
 `COMPILEALL_SOURCE_DIRS` constant; install.js mirrors the same list.
 Tests at
 [cli/tests/test_build_compile_pipeline.py](../cli/tests/test_build_compile_pipeline.py)
-lock the contract.
-
-Without this step on first launch, every `.py` import compiles
-on-the-fly and the first launch is ~2× slower. Repeated launches use
-the OS file cache anyway, so the steady-state difference is small —
-but the user-visible "first run after `git pull`" is dominated by it.
+and
+[cli/tests/test_release_pipeline_config.py](../cli/tests/test_release_pipeline_config.py)
+lock the contract (including the `compile-bytecode = true` setting).
 
 ## How to reproduce a measurement
 
@@ -182,6 +229,9 @@ formula bound check across 100 × MAX_ATTEMPTS draws.
 These were observed and fixed; the lessons are durable.
 
 - **Eager `from langchain_openai import ChatOpenAI` at module top.** Cost ~21 s cold on Windows because it transitively pulls openai SDK + tiktoken + httpx wrappers. With `from __future__ import annotations` already in place, all type hints become strings; no eager import was structurally required. Lazy via per-function local imports + a small `BaseMessage`-only eager hold-out.
+- **Eager SDK import at LLM provider registration, just to reference typed exception classes.** The `services/llm/providers/*` registration blocks did `import anthropic` / `import openai` / `from google.genai import errors` at module bottom solely to populate `ProviderSpec.sdk_exception_types` — re-creating the anti-pattern above through the raw SDKs (~7.6 s warm / ~45 s cold for the AIService import vs the 703 ms baseline; google.genai alone was ~4 s warm / ~15 s cold). Fixed with lazy `"module:ClassName"` refs (`ProviderSpec.sdk_exception_refs`) resolved via `pkgutil.resolve_name` at except/read time — by then the provider factory has already imported the SDK, so resolution is a `sys.modules` cache hit. Locked by [server/tests/llm/test_lazy_sdk_imports.py](../server/tests/llm/test_lazy_sdk_imports.py) (subprocess purity probe). When adding a provider: pass a string ref, never import the SDK at module level.
+- **Unconditional `client/node_modules/.vite` wipe on every `company dev`.** Forced a full esbuild dependency re-optimization (1-2 minutes on Windows) on every first page load. Vite self-invalidates the dep cache via lockfile/config/NODE_ENV hashes in `.vite/deps/_metadata.json`; the wipe was pure waste on a stable lockfile. Replaced with `company dev --force` → `VITE_FORCE=1` → `optimizeDeps.force` (Vite's own re-bundle mechanism), plus `optimizeDeps.include` for the heavy lazily-reached deps so late discovery can't trigger the mid-session re-optimization behind the "Outdated Optimize Dep" 504 (vitejs/vite#14284).
+- **Synchronous temporalio `Worker()` construction on the event loop.** The constructor derives a default build id by MD5-hashing the bytecode of every module in `sys.modules` (disk reads included) — ~3.1 s at our module count, freezing the loop and inflating concurrent boot work (`broadcaster.refresh_whatsapp` measured 4.2 s vs its ~0.4 s siblings). The value is memoized SDK-globally, so `TemporalWorkerManager.start()` pre-warms it once via `asyncio.to_thread(load_default_build_id)` before constructing the manager worker; all pool workers then construct cheaply. Any new long synchronous call in an async startup path should get the same `to_thread` treatment.
 - **Recursive `setTimeout` retry chain in `useEffect` without `AbortController`.** Survived unmount, leaked timers, called `setState` on stale closures. The React docs explicitly flag this in [https://react.dev/reference/react/useEffect](https://react.dev/reference/react/useEffect). Replaced with TanStack Query's `signal`-aware `queryFn`.
 - **Flat `setTimeout(connect, 3000)` reconnect loop.** No exponential backoff, no jitter, no `code === 1000` honouring, no message replay. Replaced with PartySocket — see [client/src/contexts/WebSocketContext.tsx](../client/src/contexts/WebSocketContext.tsx).
 - **`if (event.code !== 1000)` magic numbers** scattered through the WS lifecycle. Replaced with `WS_CLOSE.NORMAL_CLOSURE` from [connectionConfig.ts](../client/src/lib/connectionConfig.ts) per RFC 6455 §7.4.1.
@@ -193,9 +243,13 @@ Tracked but explicitly **not** in any active plan.
 
 | Item | Estimated saving | Notes |
 |---|---|---|
+| Lazy `googleapiclient` import in `nodes/google` (`_option_loaders.py` / `_oauth.py` / `_base.py` import `googleapiclient.discovery` at module top) | ~2-4 s of the cold plugin walk | googleapiclient is 98 MB / 612 files on disk; now the single biggest import cost left on the cold boot path. Move `from googleapiclient.discovery import build` into function bodies (same idiom as `services/plugin/credential.py`). `nodes/telegram/_service.py`'s top-level `telegram` imports are the smaller sibling. |
+| Defer first-launch example import off the workflows REST request | ~8-10 s of first-launch first paint | `routers/database.py:get_all_workflows` awaits `import_examples_for_user` inline, holding the HTTP response. Move to a lifespan background task (pattern: `_refresh_registry` / `_refresh_all_services` / Temporal init in `main.py`) + emit `workflow_lifecycle("imported")` per example so the sidebar refreshes. Secondary: negative cache in `AuthService.has_valid_key` (validation does one credentials-DB read per declared credential per node). |
+| Cold-boot lifespan I/O (9.6 s measured 2026-07-14 vs 1.5 s pre-fix cold boot) | unclear — needs a re-run | Fresh-DB creation 4.4 s + salt/PBKDF2 + encryption ~3 s under Defender/disk contention now that the whole boot compresses into ~20 s. May be noise; measure before optimising. |
 | Plugin walker lazy-loading | ~0.5-0.8 s on server-ready | Would need to defer registration until first NodeSpec request rather than at module-import time. Touches every `BaseNode` subclass — biggest blast radius of the candidates. |
 | `BaseMessage`-free agent loop (drop the only eager `langchain_core.messages` import in `services/ai.py`) | ~0.3-0.5 s | Native-SDK provider classes already use their own message types; `_run_agent_loop` could be retyped against them and the eager import dropped. |
 | `+5 s` HTTP-ready → first-WS-connect gap | up to 5 s | Diagnostics needed (see "remaining +5 s gap"). May reveal nothing actionable. |
+| Supervisor backend `ready_timeout` (default 30 s, shortest of the three services) | cosmetic | The probe is inert (one-shot, no restart/gating) but a >30 s boot prints an alarming "timed out waiting for port 3010" and skips the ready line. Post-fix boots fit the window; revisit only if cold boots regress past 30 s. |
 | Standalone Nuitka / PyOxidizer release binary | full Python interpreter init (~0.4 s) + `.pyc` regeneration on cold disk | User explicitly declined when scoping the build pipeline; revisit if "ship a single binary" becomes a product requirement. |
 
 ## References

--- a/docs-internal/release_build_pipeline.md
+++ b/docs-internal/release_build_pipeline.md
@@ -11,7 +11,7 @@ User scope (confirmed before this work): stay on npm distribution; **no** Nuitka
 | TypeScript type-check | `@typescript/native-preview` (tsgo) | Microsoft's Go-port of `tsc`, ~10x faster on `--noEmit`. Type-check only — JS emit in tsgo is still preview. Vite/esbuild keep producing the actual JS bundles. Stays in `devDependencies`, never ships to users. |
 | Vite output | `manualChunks` + `target: 'es2022'` | Split heavy libs (reactflow, radix-ui, lobehub, react-markdown stack) so the main bundle no longer hits the 1500KB warning ceiling. ES2022 unlocks `findLast` / optional-chaining-assignment without polyfills (Chrome 94+, FF 93+, Safari 15.4+ — within React 19 / Tailwind 4 baseline). |
 | Node sidecar | `esbuild` bundle to `dist/index.js`, run via `node` | Drops tsx interpreter startup (~500ms-1s every server boot). `--packages=external` keeps Express in `node_modules/` for patch flow. |
-| Python | `python -O -m compileall -q -j 0 server/` | Pre-compile bytecode. Implemented as step `[5/6]` in [`cli/commands/build.py`](../cli/commands/build.py) (`COMPILEALL_SOURCE_DIRS` constant lists the dirs). ~5-10s cold-start gain. `-O` strips asserts + `__debug__` branches. |
+| Python | `python -m compileall -q -j 0 <project dirs>` + `[tool.uv] compile-bytecode = true` | Pre-compile bytecode. Implemented as step `[5/6]` in [`cli/commands/build.py`](../cli/commands/build.py) (`COMPILEALL_SOURCE_DIRS` constant lists the dirs); `server/pyproject.toml`'s `compile-bytecode = true` makes `uv sync` (step `[4/6]`) compile `.venv/` site-packages too. No `-O`: every runtime launches python without `-O`, and per PEP 488 a non-optimized interpreter only loads plain `.pyc` — the earlier `-O` invocation produced `.opt-1.pyc` that nothing ever loaded (fixed 2026-07-14; ~30-50s cold-start gain, see [performance.md](performance.md)). |
 
 ## Implementation steps
 
@@ -48,15 +48,26 @@ Keep `sourcemap: analyze` (already correct), keep React Compiler config.
 
 ### 4. Python bytecode pre-compile
 
-- [`cli/commands/build.py`](../cli/commands/build.py) → after `uv sync` (step `[4/6]`), step `[5/6]` runs:
+Two halves (both required; see [performance.md](performance.md) for the
+2026-07-14 cold-boot measurements that motivated the split):
+
+- `server/pyproject.toml` → `[tool.uv] compile-bytecode = true` makes
+  `uv sync` (step `[4/6]`) compile all `.venv/` site-packages at install
+  time. uv's default is **false** — without this, every dependency `.py`
+  compiles lazily on the first import after a fresh sync.
+- [`cli/commands/build.py`](../cli/commands/build.py) → step `[5/6]`
+  covers the project's own source:
   ```python
   run(
-      uv_run("python", "-O", "-m", "compileall", "-q", "-j", "0", *COMPILEALL_SOURCE_DIRS),
+      uv_run("python", "-m", "compileall", "-q", "-j", "0", *COMPILEALL_SOURCE_DIRS),
       cwd=server_cwd,
       check=False,  # missing pyc is non-fatal — runtime regenerates as needed
   )
   ```
-  The list of source dirs is the public `cli.commands.build.COMPILEALL_SOURCE_DIRS` constant — `scripts/install.js` mirrors it.
+  No `-O`: runtimes never launch python with `-O`, so plain `.pyc` is the
+  only bytecode flavor that gets loaded (PEP 488). The list of source
+  dirs is the public `cli.commands.build.COMPILEALL_SOURCE_DIRS`
+  constant — `scripts/install.js` mirrors it.
 
 The npm tarball still excludes `__pycache__/` per `package.json` `files` (cross-Python-minor pyc fragility) — `compileall` runs on the user's machine via `company build` or `scripts/install.js` post-install.
 
@@ -70,7 +81,7 @@ The npm tarball still excludes `__pycache__/` per `package.json` `files` (cross-
 
 - `scripts/install.js` → after `uv sync`:
   1. `npm --prefix server/nodejs run build` — produce `dist/index.js`
-  2. `python -O -m compileall -q -j 0 server/` — same as build.py
+  2. `python -m compileall -q -j 0 <COMPILEALL_SOURCE_DIRS>` — same shape as build.py (no `-O`; locked in sync by `cli/tests/test_release_pipeline_config.py`)
 
 Idempotent on re-runs (compileall only rewrites stale pyc; esbuild is deterministic).
 
@@ -86,8 +97,9 @@ Idempotent on re-runs (compileall only rewrites stale pyc; esbuild is determinis
 | `client/vite.config.js` | + manualChunks, target, lower warning |
 | `server/nodejs/package.json` | + esbuild devDep, build script, change start |
 | `server/nodejs/.gitignore` | new — ignore `dist/` |
-| `cli/commands/build.py` | + compileall step (`[5/6]`), `COMPILEALL_SOURCE_DIRS` constant |
+| `cli/commands/build.py` | + compileall step (`[5/6]`, plain `.pyc` — no `-O`), `COMPILEALL_SOURCE_DIRS` constant |
 | `scripts/install.js` | + sidecar bundle + compileall calls |
+| `server/pyproject.toml` | `[tool.uv] compile-bytecode = true` — `uv sync` compiles `.venv/` site-packages |
 | `.github/workflows/release.yml` | + typecheck gate before build |
 
 ## Verification
@@ -95,7 +107,7 @@ Idempotent on re-runs (compileall only rewrites stale pyc; esbuild is determinis
 1. `pnpm --filter react-flow-client run typecheck` → <5s, zero errors.
 2. `ANALYZE=1 pnpm --filter react-flow-client run build` → open `client/dist/stats.html`. Expect: no chunk above 600 KB gz, main < 200 KB gz, `vendor-flow` split.
 3. `cd server/nodejs && npm run build && node dist/index.js` → starts on :3020 in <100ms.
-4. `cd server && uv run python -O -m compileall -q -j 0 .` → `__pycache__/*.opt-1.pyc` present.
+4. `cd server && uv run python -m compileall -q -j 0 services` → plain `__pycache__/*.pyc` present (no `.opt-1.pyc` — nothing loads those).
 5. Cold-start: clean install + `company start > start.log 2>&1` → `Application startup complete` at ≤+50s (was +66.9s).
 6. `npm pack --dry-run` → `server/nodejs/dist/index.js` included; no `__pycache__/`; tarball size ≤ v0.0.76.
 7. Smoke: `company start` → load http://localhost:3000 → run "AI Assistant" example → agent responds.

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -209,17 +209,20 @@ try {
   }
   run('uv sync', serverDir, 600000);  // 10 min timeout
 
-  // Pre-compile our Python sources to optimised bytecode (.opt-1.pyc).
-  // `-O` strips assertions and `__debug__` branches; `-q` silences
-  // per-file output; `-j 0` parallelises across CPU cores. Scoped to
-  // our own source dirs — `uv sync` already compiles `.venv/` and
-  // some site-packages contain non-Python template files that would
-  // log spurious errors. Failure is non-fatal: the runtime regenerates
-  // missing .pyc on first import. Trims a few seconds off cold start.
+  // Pre-compile our Python sources to plain .pyc. No `-O`: every runtime
+  // launches python without -O, and per PEP 488 a non-optimized
+  // interpreter never loads `.opt-1.pyc` — plain .pyc is the file that
+  // actually gets used. `-q` silences per-file output; `-j 0`
+  // parallelises across CPU cores. Scoped to our own source dirs —
+  // `.venv/` is compiled by `uv sync` itself ([tool.uv]
+  // compile-bytecode = true in server/pyproject.toml) and some
+  // site-packages contain non-Python template files that would log
+  // spurious errors. Failure is non-fatal: the runtime regenerates
+  // missing .pyc on first import. Trims tens of seconds off cold start.
   step++;
   console.log(`[${step}/${totalSteps}] Compiling Python bytecode...`);
   try {
-    run('uv run python -O -m compileall -q -j 0 services core nodes routers models middleware main.py constants.py', serverDir, 120000);
+    run('uv run python -m compileall -q -j 0 services core nodes routers models middleware main.py constants.py', serverDir, 120000);
   } catch (err) {
     console.log(`  Warning: bytecode compilation failed (non-fatal): ${err.message}`);
   }

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -245,3 +245,9 @@ ignore = [
 
 [tool.uv]
 index-url = "https://pypi.org/simple"
+# Compile site-packages to .pyc at `uv sync` time (uv default is false —
+# without this, all ~9,700 dependency .py files compile lazily on the
+# FIRST import after a fresh sync, adding tens of seconds to a post-clean
+# cold boot on Windows). Trades longer sync for faster startup, per the
+# uv docs' recommendation for startup-critical applications.
+compile-bytecode = true

--- a/server/services/ai.py
+++ b/server/services/ai.py
@@ -33,13 +33,13 @@ from typing import Awaitable, Dict, Any, List, Optional, Callable, Type, TYPE_CH
 from langchain_core.messages import BaseMessage  # eager: type hint for _run_agent_loop
 import json
 
-# Eager imports — both are tiny and read on every chat/agent execution
-# path. ``openai`` is the canonical SDK whose typed exception hierarchy
-# (``BadRequestError`` / ``AuthenticationError`` / ``RateLimitError`` / …)
-# is the contract this module dispatches on; ``NodeUserError`` is the
-# framework's "user-correctable, no-traceback" sentinel used to surface
-# those typed errors cleanly through ``BaseNode.execute()``.
-import openai
+# ``NodeUserError`` is the framework's "user-correctable, no-traceback"
+# sentinel used to surface typed SDK errors cleanly through
+# ``BaseNode.execute()``. The ``openai`` SDK itself is imported
+# function-locally in ``execute_agent`` / ``execute_chat_agent`` (its
+# only consumers here, via ``except openai.OpenAIError``) — a top-level
+# import cost seconds of boot time and re-created the eager-LLM-SDK
+# anti-pattern (docs-internal/performance.md).
 from services.plugin import NodeUserError
 
 if TYPE_CHECKING:
@@ -1583,6 +1583,8 @@ class AIService:
             workflow_id: Optional workflow ID for scoped status broadcasts
             context: Optional execution context with nodes, edges for nested agent delegation
         """
+        import openai  # local: bound before the try whose except clause needs it
+
         from langchain_core.messages import HumanMessage, SystemMessage
 
         start_time = time.time()
@@ -2131,6 +2133,8 @@ class AIService:
             workflow_id: Optional workflow ID for scoped status broadcasts
             context: Optional execution context with nodes, edges for nested agent delegation
         """
+        import openai  # local: bound before the try whose except clause needs it
+
         from langchain_core.messages import HumanMessage, SystemMessage
 
         start_time = time.time()

--- a/server/services/llm/providers/_compat.py
+++ b/server/services/llm/providers/_compat.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 
 from typing import Tuple
 
-import openai as _openai_sdk
-
 from core.logging import get_logger
 from services.llm.providers.openai import OpenAIProvider
 from services.llm.registry import ProviderSpec, register_provider
@@ -100,7 +98,7 @@ def _register_compat_providers() -> None:
             ProviderSpec(
                 name=name,
                 factory=OpenAIProvider,
-                sdk_exception_types=(_openai_sdk.OpenAIError,),
+                sdk_exception_refs=("openai:OpenAIError",),
                 client_kwargs={"base_url": base_url},
             )
         )

--- a/server/services/llm/providers/anthropic.py
+++ b/server/services/llm/providers/anthropic.py
@@ -185,19 +185,18 @@ class AnthropicProvider:
 # ---------------------------------------------------------------------------
 # Plugin self-registration
 # ---------------------------------------------------------------------------
-# Module load triggers registration into the global ProviderRegistry. The
-# eager top-level ``import anthropic`` is required to resolve the typed
-# ``APIError`` class used by the unifier's translation layer; the SDK is
-# small enough that the cost is in the same band as the existing eager
-# ``import openai`` in ``services/ai.py``.
+# Module load triggers registration into the global ProviderRegistry.
+# The typed ``APIError`` class is declared as a lazy "module:Class" ref
+# (resolved via ``pkgutil.resolve_name`` at except/read time) so that
+# registration never imports the SDK — the eager import here used to
+# cost seconds of boot time (docs-internal/performance.md).
 
-import anthropic as _anthropic_sdk
 from services.llm.registry import ProviderSpec, register_provider
 
 register_provider(
     ProviderSpec(
         name="anthropic",
         factory=AnthropicProvider,
-        sdk_exception_types=(_anthropic_sdk.APIError,),
+        sdk_exception_refs=("anthropic:APIError",),
     )
 )

--- a/server/services/llm/providers/gemini.py
+++ b/server/services/llm/providers/gemini.py
@@ -268,14 +268,17 @@ class GeminiProvider:
 # translates it into ``NodeUserError`` at one catch site so the error
 # surfaces as a single WARN line through ``BaseNode.execute()`` instead
 # of bubbling up as a bare ``RuntimeError`` traceback.
+#
+# Declared as a lazy "module:Class" ref — ``google.genai`` is the single
+# most expensive SDK import on the boot path (~4s warm / ~15s cold via
+# google.auth + api_core + protobuf); the ref defers it to first use.
 
-from google.genai import errors as _google_genai_errors
 from services.llm.registry import ProviderSpec, register_provider
 
 register_provider(
     ProviderSpec(
         name="gemini",
         factory=GeminiProvider,
-        sdk_exception_types=(_google_genai_errors.APIError,),
+        sdk_exception_refs=("google.genai.errors:APIError",),
     )
 )

--- a/server/services/llm/providers/openai.py
+++ b/server/services/llm/providers/openai.py
@@ -179,22 +179,21 @@ class OpenAIProvider:
 # ---------------------------------------------------------------------------
 # Plugin self-registration
 # ---------------------------------------------------------------------------
-# Registers ``openai`` into the global registry. The ``openai`` SDK is
-# already eagerly imported by ``services/ai.py`` so the module-level
-# import here is free (Python caches the module).
+# Registers ``openai`` into the global registry. The typed
+# ``OpenAIError`` class is declared as a lazy "module:Class" ref so
+# registration never imports the SDK at boot.
 #
 # OpenAI-compatible providers (xai / deepseek / kimi / mistral / ollama /
 # lmstudio) register separately in ``_compat.py`` — they reuse
 # ``OpenAIProvider`` as their factory but pin ``base_url`` via
 # ``ProviderSpec.client_kwargs`` rather than per-provider Python.
 
-import openai as _openai_sdk
 from services.llm.registry import ProviderSpec, register_provider
 
 register_provider(
     ProviderSpec(
         name="openai",
         factory=OpenAIProvider,
-        sdk_exception_types=(_openai_sdk.OpenAIError,),
+        sdk_exception_refs=("openai:OpenAIError",),
     )
 )

--- a/server/services/llm/providers/openrouter.py
+++ b/server/services/llm/providers/openrouter.py
@@ -85,15 +85,14 @@ class OpenRouterProvider(OpenAIProvider):
 # ---------------------------------------------------------------------------
 # OpenRouter rides the OpenAI Python SDK with a different ``base_url`` +
 # extra headers, so its typed exceptions are ``openai.OpenAIError``
-# subclasses — same exception tuple as the openai provider above.
+# subclasses — same lazy exception ref as the openai provider.
 
-import openai as _openai_sdk
 from services.llm.registry import ProviderSpec, register_provider
 
 register_provider(
     ProviderSpec(
         name="openrouter",
         factory=OpenRouterProvider,
-        sdk_exception_types=(_openai_sdk.OpenAIError,),
+        sdk_exception_refs=("openai:OpenAIError",),
     )
 )

--- a/server/services/llm/registry.py
+++ b/server/services/llm/registry.py
@@ -9,6 +9,8 @@ inside ``services/ai.py`` after this layer is wired.
 
 from __future__ import annotations
 
+import functools
+import pkgutil
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Tuple, Type
 
@@ -17,6 +19,22 @@ from services.llm.protocol import LLMProvider
 from services.plugin import NodeUserError
 
 logger = get_logger(__name__)
+
+
+@functools.lru_cache(maxsize=None)
+def _resolve_exc(ref: str) -> Type[BaseException]:
+    """Resolve a ``"module:ClassName"`` ref to the exception class.
+
+    Called lazily from ``ProviderSpec.sdk_exception_types`` — by the time
+    anything needs the resolved classes (an ``except`` clause matching a
+    raised SDK error, or a test reading the tuple), the provider factory
+    has already imported the SDK to build its client, so this is a
+    ``sys.modules`` cache hit, never a cold import on the boot path.
+    """
+    obj = pkgutil.resolve_name(ref)
+    if not (isinstance(obj, type) and issubclass(obj, BaseException)):
+        raise TypeError(f"{ref!r} did not resolve to an exception class: {obj!r}")
+    return obj
 
 
 @dataclass(frozen=True)
@@ -29,11 +47,14 @@ class ProviderSpec:
             ``providers.<name>`` block in ``llm_defaults.json``.
         factory: callable returning an ``LLMProvider`` instance.
             Invoked as ``factory(api_key=..., proxy_url=..., **client_kwargs)``.
-        sdk_exception_types: tuple of typed SDK error classes raised by
-            this provider's underlying SDK. The unifier wraps a single
-            ``except spec.sdk_exception_types`` around every call site so
-            user-correctable errors surface as ``NodeUserError`` without
-            a per-provider branch in ai.py.
+        sdk_exception_refs: tuple of ``"module:ClassName"`` refs (the
+            packaging entry-points format, resolved via
+            ``pkgutil.resolve_name``) naming the typed error classes
+            raised by this provider's SDK. Refs — not classes — so that
+            registering a provider at boot never imports its SDK
+            (docs-internal/performance.md anti-pattern; cost ~7s warm /
+            ~45s cold across openai + anthropic + google.genai). The
+            resolved classes are exposed by ``sdk_exception_types``.
         client_kwargs: static keyword arguments passed to ``factory`` on
             every instantiation. Used by OpenAI-compatible providers
             (xai / deepseek / kimi / mistral / ollama / lmstudio / groq /
@@ -42,8 +63,18 @@ class ProviderSpec:
 
     name: str
     factory: Callable[..., LLMProvider]
-    sdk_exception_types: Tuple[Type[Exception], ...]
+    sdk_exception_refs: Tuple[str, ...]
     client_kwargs: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def sdk_exception_types(self) -> Tuple[Type[BaseException], ...]:
+        """Resolved typed SDK error classes.
+
+        The unifier wraps a single ``except spec.sdk_exception_types``
+        around every call site so user-correctable errors surface as
+        ``NodeUserError`` without a per-provider branch in ai.py.
+        """
+        return tuple(_resolve_exc(ref) for ref in self.sdk_exception_refs)
 
 
 _REGISTRY: Dict[str, ProviderSpec] = {}
@@ -60,9 +91,12 @@ def register_provider(spec: ProviderSpec) -> None:
     reload cycles). Re-registration with a different spec raises so
     accidental shadowing is loud.
     """
-    if not spec.sdk_exception_types:
+    # Check the raw refs, NOT the resolving property — reading the
+    # property here would import every SDK at registration time and
+    # defeat the lazy-ref design.
+    if not spec.sdk_exception_refs:
         raise ValueError(
-            f"ProviderSpec({spec.name!r}) declares empty sdk_exception_types. "
+            f"ProviderSpec({spec.name!r}) declares empty sdk_exception_refs. "
             "Every provider must surface its typed SDK error class so the "
             "unifier can translate it into NodeUserError."
         )

--- a/server/services/temporal/worker.py
+++ b/server/services/temporal/worker.py
@@ -185,6 +185,29 @@ class TemporalWorkerManager:
             # / interceptors into the effective worker configuration —
             # the framework worker stays plugin-agnostic.
             plugin_list = temporal_plugins()
+
+            # The Worker() constructor derives its default build id by
+            # MD5-hashing the bytecode of every module in sys.modules
+            # (disk reads included) — a synchronous ~3s stall at our
+            # module count (152 plugins + LLM SDK stack) that freezes
+            # the event loop and starves concurrent boot work (e.g.
+            # broadcaster refreshes). The result is memoized in an SDK
+            # module global, so one off-loop call here makes this
+            # Worker AND every TemporalWorkerPool worker construct
+            # cheaply. load_default_build_id is not re-exported from
+            # temporalio.worker (private module in 1.30); if an SDK
+            # upgrade moves it, skip the pre-warm and pay the
+            # synchronous cost again rather than fail startup.
+            try:
+                from temporalio.worker._worker import load_default_build_id
+            except ImportError:
+                logger.warning(
+                    "temporalio private API moved: load_default_build_id "
+                    "unavailable, skipping off-loop build-id pre-warm"
+                )
+            else:
+                await asyncio.to_thread(load_default_build_id)
+
             self._worker = Worker(
                 self.client,
                 task_queue=self.task_queue,

--- a/server/tests/llm/test_lazy_sdk_imports.py
+++ b/server/tests/llm/test_lazy_sdk_imports.py
@@ -1,0 +1,84 @@
+"""Boot-path purity: registering LLM providers must not import their SDKs.
+
+The provider registration blocks used to do eager ``import anthropic`` /
+``import openai`` / ``from google.genai import errors`` at module bottom
+just to populate ``ProviderSpec.sdk_exception_types`` — reintroducing the
+eager-LLM-SDK-at-boot anti-pattern (docs-internal/performance.md) at
+~7s warm / ~45s cold. The specs now carry lazy ``"module:ClassName"``
+refs resolved via ``pkgutil.resolve_name`` at except/read time.
+
+These tests run the import in a clean subprocess (the pytest process
+itself has SDKs loaded by other tests) and assert none of the heavy SDK
+modules land in ``sys.modules``. They are the guard that keeps the next
+provider from quietly reintroducing the eager import.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SERVER_DIR = Path(__file__).resolve().parents[2]
+
+_HEAVY_SDKS = ("openai", "anthropic", "google.genai")
+
+
+def _run_probe(code: str) -> str:
+    """Run ``code`` in a clean interpreter with cwd=server/ and return stdout."""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=SERVER_DIR,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"probe subprocess failed (rc={result.returncode}):\n{result.stderr}"
+    )
+    return result.stdout
+
+
+def test_importing_llm_package_does_not_import_sdks():
+    out = _run_probe(
+        "import sys\n"
+        "import services.llm\n"
+        "import services.llm.providers\n"
+        f"leaked = [m for m in {_HEAVY_SDKS!r} if m in sys.modules]\n"
+        "print('LEAKED=' + ','.join(leaked))\n"
+    )
+    assert "LEAKED=\n" in out or out.strip().endswith("LEAKED="), (
+        f"provider registration imported heavy SDKs at boot: {out!r}"
+    )
+
+
+def test_importing_services_ai_does_not_import_openai():
+    out = _run_probe(
+        "import sys\n"
+        "import services.ai\n"
+        "print('LEAKED=' + ('openai' if 'openai' in sys.modules else ''))\n"
+    )
+    assert out.strip().endswith("LEAKED="), (
+        f"services.ai imported the openai SDK at module level: {out!r}"
+    )
+
+
+def test_all_registered_refs_resolve_to_exception_classes():
+    """Every declared ref must resolve — typo guard, run in-process.
+
+    Complements ``test_plugin_shape.py``'s non-empty/exception-class
+    checks: this exercises the actual lazy resolution path end-to-end
+    for every registered provider.
+    """
+    import services.llm.providers  # noqa: F401 — triggers registration
+
+    from services.llm.registry import all_providers, get_provider
+
+    for name in all_providers():
+        spec = get_provider(name)
+        resolved = spec.sdk_exception_types
+        assert resolved, f"provider {name!r} resolved to an empty tuple"
+        for exc in resolved:
+            assert isinstance(exc, type) and issubclass(exc, BaseException), (
+                f"provider {name!r} ref resolved to non-exception: {exc!r}"
+            )

--- a/server/tests/llm/test_unifier_incompatible_models_filter.py
+++ b/server/tests/llm/test_unifier_incompatible_models_filter.py
@@ -36,7 +36,7 @@ def _swap_provider_factory(name: str, models: list[str]):
     _registry._REGISTRY[name] = ProviderSpec(
         name=original.name,
         factory=lambda **kwargs: stub_client,
-        sdk_exception_types=original.sdk_exception_types,
+        sdk_exception_refs=original.sdk_exception_refs,
         client_kwargs=original.client_kwargs,
     )
     return original

--- a/server/tests/llm/test_unifier_typed_errors.py
+++ b/server/tests/llm/test_unifier_typed_errors.py
@@ -45,11 +45,11 @@ def _replace_factory(provider_name: str, exc: Exception):
     """Re-register the named provider with a factory returning the failing client."""
     original = get_provider(provider_name)
     failing_client = _stub_client_that_raises(exc)
-    # Build a wrapping spec — same exception tuple, factory swapped for a stub
+    # Build a wrapping spec — same exception refs, factory swapped for a stub
     spec = ProviderSpec(
         name=original.name,
         factory=lambda **kwargs: failing_client,
-        sdk_exception_types=original.sdk_exception_types,
+        sdk_exception_refs=original.sdk_exception_refs,
         client_kwargs=original.client_kwargs,
     )
     # Direct registry write (bypasses register_provider's conflict guard


### PR DESCRIPTION
## Summary

Two captured boot logs (warm dev boot ~2m40s to usable UI; post-`company clean` cold boot ~71s to "Application startup complete" vs the 2.90s baseline) were analyzed down to root causes. The suspected Temporal changes were NOT the bottleneck (~0.6s import + ~3.1s post-ready background hash). Four fixes, each independently revertible:

1. **perf(llm)**: provider registration eagerly imported openai/anthropic/google.genai just to reference typed exception classes (~7.6s warm / ~45s cold). `ProviderSpec` now carries lazy `"module:Class"` refs resolved via stdlib `pkgutil.resolve_name` at except/read time — a sys.modules cache hit, since the provider factory has already imported the SDK by then. All 12 providers now register in **17ms** cold. New subprocess purity test locks the contract.
2. **perf(build)**: `uv sync` never compiled site-packages (uv default is false) and the build's `-O` compileall emitted `.opt-1.pyc` that no runtime loads (PEP 488 — every entry point runs python without `-O`). Now: `[tool.uv] compile-bytecode = true` + `-O`-less compileall. Post-clean cold boot: **71s -> 21.5s** measured.
3. **perf(dev)**: `company dev` unconditionally wiped the Vite dep cache, forcing a 1-2 minute esbuild re-optimize on every boot. The cache is now preserved (Vite self-invalidates via lockfile/config hashes); `company dev --force` maps to Vite's own `optimizeDeps.force`; `optimizeDeps.include` pre-bundles the heavy lazily-reached deps that caused the "Outdated Optimize Dep" 504 the wipe was fighting.
4. **perf(temporal)**: the `Worker()` constructor synchronously MD5-hashes the bytecode of all of sys.modules (~3.1s) on the event loop, starving concurrent boot work. The memoized `load_default_build_id` is now pre-warmed via `asyncio.to_thread`; post-fix logs show broadcaster refreshes and the WhatsApp RPC handshake interleaving inside the worker-start window.

Plus a docs commit recording the measured numbers and three new anti-pattern entries in performance.md.

## Measured results (cold.txt before/after, same day)

| Metric | Before | After |
|---|---|---|
| Application startup complete (cold post-clean) | ~71s | **21.5s** |
| LLM provider registration (cold) | 44.6s | **17ms** |
| Warm AIService import | 7.6s | ~0.7s baseline |
| Vite re-optimize per warm dev boot | ~2min | none (cache reused) |
| Event-loop freeze during Temporal worker start | ~3.1s | none (off-loop) |

## Testing

- Full suites green: 1,769 server + 162 client + 103 CLI tests
- New `tests/llm/test_lazy_sdk_imports.py` (subprocess import-purity probe)
- Updated pinning tests for the compileall shape + `compile-bytecode` setting
- Live cold-boot verification captured in `docs-internal/performance.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)