### PR TITLE
fix(ui): remove phantom CLI flags from help; correct onboarding provider strings

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -34,13 +34,10 @@ Commands:
 ${Object.entries(COMMANDS).map(([cmd, desc]) => `  ${cmd.padEnd(14)} ${desc}`).join('\n')}
 
 Flags:
-  --verbose, -v    Show full service logs (start)
-  --skip-whatsapp  Skip WhatsApp service (start, dev)
-  --daemon         Use uvicorn daemon backend
+  --daemon         Bind the backend to 0.0.0.0 instead of 127.0.0.1 (dev)
 
 Examples:
   company start          # Production server (clean output)
-  company start -v       # Production with full logs
   company dev            # Development with hot-reload
   company build          # Build for production
 

--- a/client/src/components/onboarding/steps/ApiKeyStep.tsx
+++ b/client/src/components/onboarding/steps/ApiKeyStep.tsx
@@ -14,7 +14,7 @@ interface ApiKeyStepProps {
 const providers = [
   { name: 'OpenAI', icon: <OpenAIIcon />, desc: 'GPT-4o, o3, o4 models', url: 'platform.openai.com' },
   { name: 'Anthropic', icon: <ClaudeIcon />, desc: 'Claude Opus, Sonnet models', url: 'console.anthropic.com' },
-  { name: 'Google', icon: <GeminiIcon />, desc: 'Gemini Pro, Flash models', url: 'aistudio.google.com' },
+  { name: 'Gemini', icon: <GeminiIcon />, desc: 'Gemini Pro, Flash models', url: 'aistudio.google.com' },
   { name: 'Groq', icon: <GroqIcon />, desc: 'Ultra-fast Llama, Qwen', url: 'console.groq.com' },
   { name: 'OpenRouter', icon: <OpenRouterIcon />, desc: 'Access 200+ models', url: 'openrouter.ai' },
   { name: 'Cerebras', icon: <CerebrasIcon />, desc: 'Fast inference on custom HW', url: 'cloud.cerebras.ai' },

--- a/client/src/components/onboarding/steps/WelcomeStep.tsx
+++ b/client/src/components/onboarding/steps/WelcomeStep.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent } from '@/components/ui/card';
 
 const features = [
   { Icon: Plug, label: '108+ Nodes', desc: 'Workflow building blocks' },
-  { Icon: Rocket, label: '6 AI Providers', desc: 'OpenAI, Claude, Gemini & more' },
+  { Icon: Rocket, label: '12 AI Providers', desc: 'OpenAI, Claude, Gemini & more' },
   { Icon: Move, label: 'Drag & Drop', desc: 'Visual workflow builder' },
   { Icon: Zap, label: 'Real-time', desc: 'Live execution & monitoring' },
 ];


### PR DESCRIPTION
## Summary

Closes out the follow-up flags from the docs-overhaul audit — the last three places where the product's own text contradicts reality.

- **bin/cli.js help**: removes `--verbose`/`-v` and `--skip-whatsapp` from the Flags block and the `company start -v` example. Neither flag is defined by any Python CLI verb (`start` takes no options; `dev` takes only `--daemon`), so Typer rejects them with `No such option` — the help was advertising commands that error. `--daemon` is now scoped to `dev` and its description matches the real Typer help string ("Bind the backend to 0.0.0.0 instead of 127.0.0.1").
- **Onboarding WelcomeStep**: "6 AI Providers" → "12 AI Providers" (verified: 11 dedicated model-node packages under `server/nodes/model/` plus xAI (Grok) via the OpenAI-compatible credential path).
- **Onboarding ApiKeyStep**: the Gemini card was labeled "Google", which both mismatches the credentials modal (catalogue `credential_providers.json` names the provider "Gemini") and collides with the unrelated "Google Workspace" OAuth provider.

## Verification

- `node --check bin/cli.js` passes.
- Repo-wide grep: no test or code references `--skip-whatsapp`, `-v`/`--verbose` for start, "6 AI Providers", or `name: 'Google'` in the onboarding path.
- String-literal-only changes in the two TSX files; no logic touched (`name` is display-only + React key).

Note: PR #51 adds `--force` to `company dev`; if that merges, its help line lands there — this PR intentionally documents only what `main` routes today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)